### PR TITLE
Add new properties in ConnectionOptions type

### DIFF
--- a/src/connection/base.js
+++ b/src/connection/base.js
@@ -7,7 +7,9 @@ export type ConnectionOptions = {
   videoCodecType?: string,
   videoBitRate?: number,
   multistream?: boolean,
-  spotlight?: number
+  spotlight?: number,
+  simulcast?: boolean,
+  simulcastQuality?: 'low' | 'middle' | 'high'
 }
 
 import { createSignalingMessage, trace, isSafari, isUnifiedChrome, replaceAnswerSdp } from '../utils';


### PR DESCRIPTION
flowの型情報に `simulcast` と `simulcastQuality` を追加しました。

ところで、READMEからは、 `simulcastQuality` は `sora.publisher` では使用できず、 `sora.subscriber` でのみ使用できるように読めますが、型情報も `sora.publisher` と `sora.subscriber` で分けるべきでしょうか？