### PR TITLE
remove type

### DIFF
--- a/dist/sora.d.ts
+++ b/dist/sora.d.ts
@@ -17,4 +17,4 @@ declare const _default: {
     version: () => string;
 };
 export default _default;
-export type { AudioCodecType, Callbacks, ConnectionBase, ConnectionOptions, ConnectionPublisher, ConnectionSubscriber, Role, SimulcastQuality, SoraConnection, VideoCodecType, };
+export { AudioCodecType, Callbacks, ConnectionBase, ConnectionOptions, ConnectionPublisher, ConnectionSubscriber, Role, SimulcastQuality, SoraConnection, VideoCodecType, };


### PR DESCRIPTION
adding 'type' make crash in typescript development with error message "Declaration or statement expected.".
solution for this error is remove "type" code
