### PR TITLE
DataChannel signaling 機能の修正

### DIFF
--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -124,7 +124,7 @@ export default class ConnectionBase {
     }
   }
 
-  private closeStream(): Promise<void> {
+  private stopStream(): Promise<void> {
     return new Promise((resolve, _) => {
       if (this.debug) {
         console.warn(
@@ -142,7 +142,7 @@ export default class ConnectionBase {
     });
   }
 
-  private closeWebSocket(): Promise<void> {
+  private disconnectWebSocket(): Promise<void> {
     return new Promise((resolve, _) => {
       if (!this.ws) {
         return resolve();
@@ -158,7 +158,7 @@ export default class ConnectionBase {
     });
   }
 
-  private closeDataChannel(): Promise<void> {
+  private disconnectDataChannel(): Promise<void> {
     return new Promise((resolve, _) => {
       if (!this.dataChannels["signaling"]) {
         return resolve();
@@ -178,7 +178,7 @@ export default class ConnectionBase {
     });
   }
 
-  private closePeerConnection(): Promise<void> {
+  private disconnectPeerConnection(): Promise<void> {
     return new Promise((resolve, _reject) => {
       if (!this.pc || this.pc.connectionState === "closed" || this.pc.connectionState === undefined) {
         return resolve();
@@ -209,10 +209,10 @@ export default class ConnectionBase {
     this.connectionId = null;
     this.authMetadata = null;
     this.remoteConnectionIds = [];
-    await this.closeStream();
-    await this.closeDataChannel();
-    await this.closeWebSocket();
-    await this.closePeerConnection();
+    await this.stopStream();
+    await this.disconnectDataChannel();
+    await this.disconnectWebSocket();
+    await this.disconnectPeerConnection();
     if (this.e2ee) {
       this.e2ee.terminateWorker();
       this.e2ee = null;

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -64,6 +64,7 @@ export default class ConnectionBase {
   };
   private ignoreDisconnectWebSocket: boolean;
   private closeWebSocket: boolean;
+  private connectionTimeout: number;
 
   constructor(
     signalingUrl: string,
@@ -78,9 +79,14 @@ export default class ConnectionBase {
     this.metadata = metadata;
     this.signalingUrl = signalingUrl;
     this.options = options;
-    // client timeout の初期値をセットする
-    if (this.options.timeout === undefined) {
-      this.options.timeout = 60000;
+    // connection timeout の初期値をセットする
+    this.connectionTimeout = 60000;
+    if (typeof this.options.timeout === "number") {
+      console.warn("@deprecated timeout option will be removed in a future version. Use connectionTimeout.");
+      this.connectionTimeout = this.options.timeout;
+    }
+    if (typeof this.options.connectionTimeout === "number") {
+      this.connectionTimeout = this.options.connectionTimeout;
     }
     // closeWebsocket の初期値をセットする
     this.closeWebSocket = true;
@@ -466,7 +472,7 @@ export default class ConnectionBase {
 
   protected setConnectionTimeout(): Promise<MediaStream> {
     return new Promise((_, reject) => {
-      if (this.options.timeout && 0 < this.options.timeout) {
+      if (0 < this.connectionTimeout) {
         this.timeoutTimerId = setTimeout(async () => {
           if (
             !this.pc ||
@@ -478,7 +484,7 @@ export default class ConnectionBase {
             await this.disconnect();
             reject(error);
           }
-        }, this.options.timeout);
+        }, this.connectionTimeout);
       }
     });
   }

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -58,7 +58,7 @@ export default class ConnectionBase {
   protected ws: WebSocket | null;
   protected callbacks: Callbacks;
   protected e2ee: SoraE2EE | null;
-  protected timeoutTimerId: number;
+  protected connectionTimeoutTimerId: number;
   protected dataChannels: {
     [key in string]?: RTCDataChannel;
   };
@@ -117,7 +117,7 @@ export default class ConnectionBase {
     };
     this.authMetadata = null;
     this.e2ee = null;
-    this.timeoutTimerId = 0;
+    this.connectionTimeoutTimerId = 0;
     this.dataChannels = {};
     this.ignoreDisconnectWebSocket = false;
     this.dataChannelSignaling = false;
@@ -473,7 +473,7 @@ export default class ConnectionBase {
   protected setConnectionTimeout(): Promise<MediaStream> {
     return new Promise((_, reject) => {
       if (0 < this.connectionTimeout) {
-        this.timeoutTimerId = setTimeout(async () => {
+        this.connectionTimeoutTimerId = setTimeout(async () => {
           if (
             !this.pc ||
             (this.pc && this.pc.connectionState !== undefined && this.pc.connectionState !== "connected")
@@ -490,7 +490,7 @@ export default class ConnectionBase {
   }
 
   protected clearConnectionTimeout(): void {
-    clearTimeout(this.timeoutTimerId);
+    clearTimeout(this.connectionTimeoutTimerId);
   }
 
   protected trace(title: string, message: unknown): void {

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -96,7 +96,7 @@ export default class ConnectionBase {
       this.closeWebSocket = this.options.closeWebSocket;
     }
     // DataChannel signaling timeout の初期値をセットする
-    this.dataChannelSignalingTimeout = 3000;
+    this.dataChannelSignalingTimeout = 180000;
     if (typeof this.options.dataChannelSignalingTimeout === "number") {
       this.dataChannelSignalingTimeout = this.options.dataChannelSignalingTimeout;
     }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -243,6 +243,7 @@ export type ConnectionOptions = {
   dataChannelSignaling?: boolean;
   ignoreDisconnectWebSocket?: boolean;
   closeWebSocket?: boolean;
+  dataChannelSignalingTimeout?: number;
 };
 
 export type Callbacks = {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -79,6 +79,7 @@ export type SignalingOfferMessage = {
   encodings?: RTCRtpEncodingParameters[];
   ignore_disconnect_websocket?: boolean;
   data_channel_signaling?: boolean;
+  data_channel_labels?: string[];
 };
 
 export type SignalingUpdateMessage = {
@@ -240,6 +241,7 @@ export type ConnectionOptions = {
   signalingNotifyMetadata?: JSONType;
   dataChannelSignaling?: boolean;
   ignoreDisconnectWebSocket?: boolean;
+  closeWebSocket?: boolean;
 };
 
 export type Callbacks = {
@@ -263,14 +265,6 @@ export type PreKeyBundle = {
 };
 
 export type Browser = "edge" | "chrome" | "safari" | "opera" | "firefox" | null;
-
-const DATA_CHANNEL_LABELS = ["signaling", "notify", "e2ee", "stats", "push"] as const;
-
-export type DataChannelLabel = typeof DATA_CHANNEL_LABELS[number];
-
-export function isDataChannelLabel(dataChannelType: string): dataChannelType is DataChannelLabel {
-  return (DATA_CHANNEL_LABELS as readonly string[]).indexOf(dataChannelType) >= 0;
-}
 
 export type TransportType = "websocket" | "datachannel";
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -236,7 +236,8 @@ export type ConnectionOptions = {
   simulcast?: boolean;
   simulcastRid?: SimulcastRid;
   clientId?: string;
-  timeout?: number;
+  timeout?: number; // deprecated option
+  connectionTimeout?: number;
   e2ee?: boolean;
   signalingNotifyMetadata?: JSONType;
   dataChannelSignaling?: boolean;


### PR DESCRIPTION
- ignore_disconnect_websocket: true の場合はデフォルトで WebSocket を切断する
- DataChannel がすべて open したあとで WebSocket を切断する
- closeWebsocket option を追加して WebSocket を切断する/切断しないを選択できるようにする
- data_channel_labels に対応する
- DataChannel がすべて開かなかった場合のタイムアウト時間(ms)を指定できるようにする
