### PR TITLE
opus_params の clock_rate を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,9 @@
 
 ## develop
 
-- [FIX] 廃止になった opus_params の clock_rate を削除する
-    - @voluntas
 - [CHANGE] ts-jest を @swc/jest に変更する
+    - @voluntas
+- [FIX] 廃止になった opus_params の clock_rate を削除する
     - @voluntas
 
 ## 2022.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [FIX] 廃止になった opus_params の clock_rate を削除する
+    - @voluntas
 - [CHANGE] ts-jest を @swc/jest に変更する
     - @voluntas
 

--- a/dist/sora.js
+++ b/dist/sora.js
@@ -1693,7 +1693,6 @@
 	    const audioPropertyKeys = ["audioCodecType", "audioBitRate"];
 	    const audioOpusParamsPropertyKeys = [
 	        "audioOpusParamsChannels",
-	        "audioOpusParamsClockRate",
 	        "audioOpusParamsMaxplaybackrate",
 	        "audioOpusParamsStereo",
 	        "audioOpusParamsSpropStereo",
@@ -1747,9 +1746,6 @@
 	        message.audio.opus_params = {};
 	        if ("audioOpusParamsChannels" in copyOptions) {
 	            message.audio.opus_params.channels = copyOptions.audioOpusParamsChannels;
-	        }
-	        if ("audioOpusParamsClockRate" in copyOptions) {
-	            message.audio.opus_params.clock_rate = copyOptions.audioOpusParamsClockRate;
 	        }
 	        if ("audioOpusParamsMaxplaybackrate" in copyOptions) {
 	            message.audio.opus_params.maxplaybackrate = copyOptions.audioOpusParamsMaxplaybackrate;

--- a/dist/sora.mjs
+++ b/dist/sora.mjs
@@ -1687,7 +1687,6 @@ function createSignalingMessage(offerSDP, role, channelId, metadata, options, re
     const audioPropertyKeys = ["audioCodecType", "audioBitRate"];
     const audioOpusParamsPropertyKeys = [
         "audioOpusParamsChannels",
-        "audioOpusParamsClockRate",
         "audioOpusParamsMaxplaybackrate",
         "audioOpusParamsStereo",
         "audioOpusParamsSpropStereo",
@@ -1741,9 +1740,6 @@ function createSignalingMessage(offerSDP, role, channelId, metadata, options, re
         message.audio.opus_params = {};
         if ("audioOpusParamsChannels" in copyOptions) {
             message.audio.opus_params.channels = copyOptions.audioOpusParamsChannels;
-        }
-        if ("audioOpusParamsClockRate" in copyOptions) {
-            message.audio.opus_params.clock_rate = copyOptions.audioOpusParamsClockRate;
         }
         if ("audioOpusParamsMaxplaybackrate" in copyOptions) {
             message.audio.opus_params.maxplaybackrate = copyOptions.audioOpusParamsMaxplaybackrate;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -12,7 +12,6 @@ export declare type SignalingAudio = boolean | {
     bit_rate?: number;
     opus_params?: {
         channels?: number;
-        clock_rate?: number;
         maxplaybackrate?: number;
         minptime?: number;
         ptime?: number;
@@ -222,7 +221,6 @@ export declare type ConnectionOptions = {
     audioCodecType?: AudioCodecType;
     audioBitRate?: number;
     audioOpusParamsChannels?: number;
-    audioOpusParamsClockRate?: number;
     audioOpusParamsMaxplaybackrate?: number;
     audioOpusParamsStereo?: boolean;
     audioOpusParamsSpropStereo?: boolean;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -15,7 +15,6 @@ export type SignalingAudio =
       bit_rate?: number;
       opus_params?: {
         channels?: number;
-        clock_rate?: number;
         maxplaybackrate?: number;
         minptime?: number;
         ptime?: number;
@@ -270,7 +269,6 @@ export type ConnectionOptions = {
   audioCodecType?: AudioCodecType;
   audioBitRate?: number;
   audioOpusParamsChannels?: number;
-  audioOpusParamsClockRate?: number;
   audioOpusParamsMaxplaybackrate?: number;
   audioOpusParamsStereo?: boolean;
   audioOpusParamsSpropStereo?: boolean;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -181,7 +181,6 @@ export function createSignalingMessage(
   const audioPropertyKeys = ["audioCodecType", "audioBitRate"];
   const audioOpusParamsPropertyKeys = [
     "audioOpusParamsChannels",
-    "audioOpusParamsClockRate",
     "audioOpusParamsMaxplaybackrate",
     "audioOpusParamsStereo",
     "audioOpusParamsSpropStereo",
@@ -236,9 +235,6 @@ export function createSignalingMessage(
     message.audio.opus_params = {};
     if ("audioOpusParamsChannels" in copyOptions) {
       message.audio.opus_params.channels = copyOptions.audioOpusParamsChannels;
-    }
-    if ("audioOpusParamsClockRate" in copyOptions) {
-      message.audio.opus_params.clock_rate = copyOptions.audioOpusParamsClockRate;
     }
     if ("audioOpusParamsMaxplaybackrate" in copyOptions) {
       message.audio.opus_params.maxplaybackrate = copyOptions.audioOpusParamsMaxplaybackrate;

--- a/packages/sdk/tests/utils.test.ts
+++ b/packages/sdk/tests/utils.test.ts
@@ -167,18 +167,6 @@ test("createSignalingMessage audioOpusParamsChannels", () => {
   expect(createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false)).toEqual(expectedMessage);
 });
 
-test("createSignalingMessage audioOpusParamsClockRate", () => {
-  const options = {
-    audioOpusParamsClockRate: 48000,
-  };
-  const expectedMessage = Object.assign({}, baseExpectedMessage, { audio: {
-    opus_params: {
-      clock_rate: options.audioOpusParamsClockRate,
-    },
-  }});
-  expect(createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false)).toEqual(expectedMessage);
-});
-
 test("createSignalingMessage audioOpusParamsMaxplaybackrate", () => {
   const options = {
     audioOpusParamsMaxplaybackrate: 48000,


### PR DESCRIPTION
Sora 2021.2.0 にて削除された opus_params の clock_rate を削除します。