### PR TITLE
ミュート状態で接続すると、replace[Video|Audio]Track しても画像・音声データが送信されないのを修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
     - @voluntas
 - [CHANGE] サンプルのチャネル ID を sora に変更する
     - @voluntas
+- [FIX] ミュート状態で接続すると、replace[Video|Audio]Track しても画像・音声データが送信されないのを修正
+    - @melpon
 
 ## 2022.3.1
 

--- a/dist/base.d.ts
+++ b/dist/base.d.ts
@@ -145,6 +145,10 @@ export default class ConnectionBase {
      * Lyra インスタンス
      */
     private lyra?;
+    /**
+     * キーとなる sender が setupSenderTransform で初期化済みかどうか
+     */
+    private senderStreamInitialized;
     constructor(signalingUrlCandidates: string | string[], role: string, channelId: string, metadata: JSONType, options: ConnectionOptions, debug: boolean);
     /**
      * SendRecv Object で発火するイベントのコールバックを設定するメソッド

--- a/dist/sora.js
+++ b/dist/sora.js
@@ -2608,7 +2608,7 @@
 	        /**
 	         * キーとなる sender が setupSenderTransform で初期化済みかどうか
 	         */
-	        this.senderStreamInitialized = new WeakMap();
+	        this.senderStreamInitialized = new WeakSet();
 	        this.role = role;
 	        this.channelId = channelId;
 	        this.metadata = metadata;
@@ -3765,7 +3765,7 @@
 	            return;
 	        }
 	        // 既に初期化済み
-	        if (this.senderStreamInitialized.get(sender) === true) {
+	        if (this.senderStreamInitialized.has(sender)) {
 	            return;
 	        }
 	        const isLyraCodec = sender.track.kind === 'audio' && this.options.audioCodecType === 'LYRA';
@@ -3802,7 +3802,7 @@
 	                readable.pipeTo(senderStreams.writable).catch((e) => console.warn(e));
 	            }
 	        }
-	        this.senderStreamInitialized.set(sender, true);
+	        this.senderStreamInitialized.add(sender);
 	    }
 	    /**
 	     * E2EE あるいはカスタムコーデックが有効になっている場合に、受信側の WebRTC Encoded Transform をセットアップする

--- a/dist/sora.mjs
+++ b/dist/sora.mjs
@@ -2602,7 +2602,7 @@ class ConnectionBase {
         /**
          * キーとなる sender が setupSenderTransform で初期化済みかどうか
          */
-        this.senderStreamInitialized = new WeakMap();
+        this.senderStreamInitialized = new WeakSet();
         this.role = role;
         this.channelId = channelId;
         this.metadata = metadata;
@@ -3759,7 +3759,7 @@ class ConnectionBase {
             return;
         }
         // 既に初期化済み
-        if (this.senderStreamInitialized.get(sender) === true) {
+        if (this.senderStreamInitialized.has(sender)) {
             return;
         }
         const isLyraCodec = sender.track.kind === 'audio' && this.options.audioCodecType === 'LYRA';
@@ -3796,7 +3796,7 @@ class ConnectionBase {
                 readable.pipeTo(senderStreams.writable).catch((e) => console.warn(e));
             }
         }
-        this.senderStreamInitialized.set(sender, true);
+        this.senderStreamInitialized.add(sender);
     }
     /**
      * E2EE あるいはカスタムコーデックが有効になっている場合に、受信側の WebRTC Encoded Transform をセットアップする

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -207,7 +207,7 @@ export default class ConnectionBase {
   /**
    * キーとなる sender が setupSenderTransform で初期化済みかどうか
    */
-  private senderStreamInitialized: WeakMap<RTCRtpSender, boolean> = new WeakMap()
+  private senderStreamInitialized: WeakSet<RTCRtpSender> = new WeakSet()
 
   constructor(
     signalingUrlCandidates: string | string[],
@@ -1448,7 +1448,7 @@ export default class ConnectionBase {
       return
     }
     // 既に初期化済み
-    if (this.senderStreamInitialized.get(sender) === true) {
+    if (this.senderStreamInitialized.has(sender)) {
       return
     }
 
@@ -1494,7 +1494,7 @@ export default class ConnectionBase {
         readable.pipeTo(senderStreams.writable).catch((e) => console.warn(e))
       }
     }
-    this.senderStreamInitialized.set(sender, true)
+    this.senderStreamInitialized.add(sender)
   }
 
   /**

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -204,6 +204,10 @@ export default class ConnectionBase {
    * Lyra インスタンス
    */
   private lyra?: LyraState
+  /**
+   * キーとなる sender が setupSenderTransform で初期化済みかどうか
+   */
+  private senderStreamInitialized: WeakMap<RTCRtpSender, boolean> = new WeakMap()
 
   constructor(
     signalingUrlCandidates: string | string[],
@@ -434,6 +438,7 @@ export default class ConnectionBase {
     }
     stream.addTrack(audioTrack)
     await transceiver.sender.replaceTrack(audioTrack)
+    await this.setupSenderTransform(transceiver.sender)
   }
 
   /**
@@ -465,6 +470,7 @@ export default class ConnectionBase {
     }
     stream.addTrack(videoTrack)
     await transceiver.sender.replaceTrack(videoTrack)
+    await this.setupSenderTransform(transceiver.sender)
   }
 
   /**
@@ -1441,6 +1447,10 @@ export default class ConnectionBase {
     if ((this.e2ee === null && this.lyra === undefined) || sender.track === null) {
       return
     }
+    // 既に初期化済み
+    if (this.senderStreamInitialized.get(sender) === true) {
+      return
+    }
 
     const isLyraCodec = sender.track.kind === 'audio' && this.options.audioCodecType === 'LYRA'
 
@@ -1484,6 +1494,7 @@ export default class ConnectionBase {
         readable.pipeTo(senderStreams.writable).catch((e) => console.warn(e))
       }
     }
+    this.senderStreamInitialized.set(sender, true)
   }
 
   /**


### PR DESCRIPTION
ミュート状態で接続すると https://github.com/shiguredo/sora-js-sdk/blob/6faba04f7d032007d05f2ae7aaafd081b24722da/packages/sdk/src/base.ts#L1441 の `sender.track === null` に引っかかって setupSenderTransform が実行されず、ミュート解除してもこの関数が呼ばれないためにこの問題が起きていました。

なので replaceVideoTrack や replaceAudioTrack が呼ばれた時に setupSenderTransform を呼ぶように修正しました。
ただし複数回 createEncodedStreams を呼ぶと例外を投げるみたいなので、既に setupSenderTransform を呼んで初期化済みかどうかを確認するようにしています。

ただ、本来１回だけ呼べばいいだけのはずの setupSenderTransform を replaceTrack の時に毎回呼ばないといけない理由って、track を見ないと LYRA で接続しているかどうかが分からないからってだけなので、どこかからその情報が取れれば、初期化済みフラグとか用意しなくても事前に setupSenderTransform できると思います。