### PR TITLE
シグナリング時に Profile などビデオコーデックパラメータの送信に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] 接続オプションとしてビデオコーデック用パラメータの送信を追加
+    - `ConnectionOptions` 型に `videoVP9Params` `videoH264Params` `videoAV1Params` フィールドを追加
+    - @tnamao
 - [ADD] GitHub Actions に Node.js 20 を追加する
     - @voluntas
 - [UPDATE] TypeScript を 5 系に上げる

--- a/dist/sora.js
+++ b/dist/sora.js
@@ -2338,7 +2338,13 @@
 	        'audioOpusParamsUsedtx',
 	    ];
 	    const audioLyraParamsPropertyKeys = ['audioLyraParamsBitrate', 'audioLyraParamsUsedtx'];
-	    const videoPropertyKeys = ['videoCodecType', 'videoBitRate'];
+	    const videoPropertyKeys = [
+	        'videoCodecType',
+	        'videoBitRate',
+	        'videoVP9Params',
+	        'videoH264Params',
+	        'videoAV1Params',
+	    ];
 	    const copyOptions = Object.assign({}, options);
 	    Object.keys(copyOptions).forEach((key) => {
 	        if (key === 'audio' && typeof copyOptions[key] === 'boolean') {
@@ -2434,6 +2440,15 @@
 	        }
 	        if ('videoBitRate' in copyOptions) {
 	            message.video['bit_rate'] = copyOptions.videoBitRate;
+	        }
+	        if ('videoVP9Params' in copyOptions) {
+	            message.video['vp9_params'] = copyOptions.videoVP9Params;
+	        }
+	        if ('videoH264Params' in copyOptions) {
+	            message.video['h264_params'] = copyOptions.videoH264Params;
+	        }
+	        if ('videoAV1Params' in copyOptions) {
+	            message.video['av1_params'] = copyOptions.videoAV1Params;
 	        }
 	    }
 	    if (message.simulcast && !enabledSimulcast() && role !== 'recvonly') {

--- a/dist/sora.mjs
+++ b/dist/sora.mjs
@@ -2332,7 +2332,13 @@ function createSignalingMessage(offerSDP, role, channelId, metadata, options, re
         'audioOpusParamsUsedtx',
     ];
     const audioLyraParamsPropertyKeys = ['audioLyraParamsBitrate', 'audioLyraParamsUsedtx'];
-    const videoPropertyKeys = ['videoCodecType', 'videoBitRate'];
+    const videoPropertyKeys = [
+        'videoCodecType',
+        'videoBitRate',
+        'videoVP9Params',
+        'videoH264Params',
+        'videoAV1Params',
+    ];
     const copyOptions = Object.assign({}, options);
     Object.keys(copyOptions).forEach((key) => {
         if (key === 'audio' && typeof copyOptions[key] === 'boolean') {
@@ -2428,6 +2434,15 @@ function createSignalingMessage(offerSDP, role, channelId, metadata, options, re
         }
         if ('videoBitRate' in copyOptions) {
             message.video['bit_rate'] = copyOptions.videoBitRate;
+        }
+        if ('videoVP9Params' in copyOptions) {
+            message.video['vp9_params'] = copyOptions.videoVP9Params;
+        }
+        if ('videoH264Params' in copyOptions) {
+            message.video['h264_params'] = copyOptions.videoH264Params;
+        }
+        if ('videoAV1Params' in copyOptions) {
+            message.video['av1_params'] = copyOptions.videoAV1Params;
         }
     }
     if (message.simulcast && !enabledSimulcast() && role !== 'recvonly') {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -30,6 +30,9 @@ export type VideoCodecType = 'VP9' | 'VP8' | 'AV1' | 'H264' | 'H265';
 export type SignalingVideo = boolean | {
     codec_type?: VideoCodecType;
     bit_rate?: number;
+    vp9_params?: JSONType;
+    h264_params?: JSONType;
+    av1_params?: JSONType;
 };
 export type Role = 'sendrecv' | 'sendonly' | 'recvonly';
 export type SignalingConnectDataChannel = {
@@ -240,6 +243,9 @@ export type ConnectionOptions = {
     video?: boolean;
     videoCodecType?: VideoCodecType;
     videoBitRate?: number;
+    videoVP9Params?: JSONType;
+    videoH264Params?: JSONType;
+    videoAV1Params?: JSONType;
     multistream?: boolean;
     spotlight?: boolean;
     spotlightNumber?: number;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -43,6 +43,9 @@ export type SignalingVideo =
   | {
       codec_type?: VideoCodecType
       bit_rate?: number
+      vp9_params?: JSONType
+      h264_params?: JSONType
+      av1_params?: JSONType
     }
 
 export type Role = 'sendrecv' | 'sendonly' | 'recvonly'
@@ -294,6 +297,9 @@ export type ConnectionOptions = {
   video?: boolean
   videoCodecType?: VideoCodecType
   videoBitRate?: number
+  videoVP9Params?: JSONType
+  videoH264Params?: JSONType
+  videoAV1Params?: JSONType
   multistream?: boolean
   spotlight?: boolean
   spotlightNumber?: number

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -218,7 +218,13 @@ export function createSignalingMessage(
     'audioOpusParamsUsedtx',
   ]
   const audioLyraParamsPropertyKeys = ['audioLyraParamsBitrate', 'audioLyraParamsUsedtx']
-  const videoPropertyKeys = ['videoCodecType', 'videoBitRate']
+  const videoPropertyKeys = [
+    'videoCodecType',
+    'videoBitRate',
+    'videoVP9Params',
+    'videoH264Params',
+    'videoAV1Params',
+  ]
   const copyOptions = Object.assign({}, options)
   ;(Object.keys(copyOptions) as (keyof ConnectionOptions)[]).forEach((key) => {
     if (key === 'audio' && typeof copyOptions[key] === 'boolean') {
@@ -318,6 +324,15 @@ export function createSignalingMessage(
     }
     if ('videoBitRate' in copyOptions) {
       message.video['bit_rate'] = copyOptions.videoBitRate
+    }
+    if ('videoVP9Params' in copyOptions) {
+      message.video['vp9_params'] = copyOptions.videoVP9Params
+    }
+    if ('videoH264Params' in copyOptions) {
+      message.video['h264_params'] = copyOptions.videoH264Params
+    }
+    if ('videoAV1Params' in copyOptions) {
+      message.video['av1_params'] = copyOptions.videoAV1Params
     }
   }
 


### PR DESCRIPTION
- [ADD] 接続オプションとしてビデオコーデック用パラメータの送信を追加
    - `ConnectionOptions` 型に `videoVP9Params` `videoH264Params` `videoAV1Params` フィールドを追加
    - @tnamao
