### PR TITLE
example 実行時に環境変数が設定されていない場合は空文字として扱う

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@
   - Node.js 18,20,21 で E2E テストを実行する
   - Chromium と E2E テストを実行する
   - @voluntas
+- [FIX] examples 実行時に環境変数が設定されていない場合は空文字にする
+  - 対象項目は SORA_CHANNEL_ID_PREFIX, VITE_SORA_CHANNEL_ID_PREFIX, VITE_ACCESS_TOKEN
+  - @miosakuma
 
 ## 2023.2.0
 

--- a/examples/e2ee/main.mjs
+++ b/examples/e2ee/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const debug = false
 Sora.initE2EE('https://sora-e2ee-wasm.shiguredo.app/2020.2/wasm.wasm').catch((e) => {

--- a/examples/messaging/main.mjs
+++ b/examples/messaging/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const debug = true
 const sora = Sora.connection(SORA_SIGNALING_URL, debug)

--- a/examples/recvonly/main.mjs
+++ b/examples/recvonly/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const debug = false
 const sora = Sora.connection(SORA_SIGNALING_URL, debug)

--- a/examples/sendonly/main.mjs
+++ b/examples/sendonly/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const channelId = `${SORA_CHANNEL_ID_PREFIX}sendonly_recvonly${SORA_CHANNEL_ID_SUFFIX}`
 const debug = false

--- a/examples/sendrecv/main.mjs
+++ b/examples/sendrecv/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const channelId = `${SORA_CHANNEL_ID_PREFIX}sendrecv${SORA_CHANNEL_ID_SUFFIX}`
 const debug = false

--- a/examples/simulcast/main.mjs
+++ b/examples/simulcast/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const debug = false
 const sora = Sora.connection(SORA_SIGNALING_URL, debug)

--- a/examples/spotlight_recvonly/main.mjs
+++ b/examples/spotlight_recvonly/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const channelId = `${SORA_CHANNEL_ID_PREFIX}spotlight_sendonly_recvonly${SORA_CHANNEL_ID_SUFFIX}`
 const debug = false

--- a/examples/spotlight_sendonly/main.mjs
+++ b/examples/spotlight_sendonly/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const channelId = `${SORA_CHANNEL_ID_PREFIX}spotlight_sendonly_recvonly${SORA_CHANNEL_ID_SUFFIX}`
 const debug = false

--- a/examples/spotlight_sendrecv/main.mjs
+++ b/examples/spotlight_sendrecv/main.mjs
@@ -1,9 +1,9 @@
 import Sora from '../../dist/sora.mjs'
 
 const SORA_SIGNALING_URL = import.meta.env.VITE_SORA_SIGNALING_URL
-const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX
-const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX
-const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN
+const SORA_CHANNEL_ID_PREFIX = import.meta.env.VITE_SORA_CHANNEL_ID_PREFIX || ''
+const SORA_CHANNEL_ID_SUFFIX = import.meta.env.VITE_SORA_CHANNEL_ID_SUFFIX || ''
+const ACCESS_TOKEN = import.meta.env.VITE_ACCESS_TOKEN || ''
 
 const channelId = `${SORA_CHANNEL_ID_PREFIX}spotlight${SORA_CHANNEL_ID_SUFFIX}`
 const debug = false


### PR DESCRIPTION
examples 実行時に環境変数が設定されていない場合 "undefined" という文字列になっていたので空文字になるよう変更しました。

対象項目は以下です。
- SORA_CHANNEL_ID_PREFIX
- VITE_SORA_CHANNEL_ID_PREFIX
- VITE_ACCESS_TOKEN

SORA_SIGNALING_URL は必須項目なので対応していません。