### PR TITLE
シングルストリーム接続は multistream: false を必須とする変更

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] シグナリングオプションの `multistream` は false の時のみシングルストリームを使用する
+  - シングルストリームを使用したい場合は `multistream: false` の指定が必須となる
+  - @tnamao
 - [CHANGE] stopAudioTrack と stopVideoTrack を非推奨にする
   - 代わりに名前を変えただけの removeAudioTrack と removeVideoTrack を用意する
   - @voluntas

--- a/packages/sdk/src/publisher.ts
+++ b/packages/sdk/src/publisher.ts
@@ -19,9 +19,10 @@ export default class ConnectionPublisher extends ConnectionBase {
    * @public
    */
   async connect(stream: MediaStream): Promise<MediaStream> {
-    if (this.options.multistream) {
+    // options.multistream が明示的に false を指定した時だけシングルストリームにする
+    if (this.options.multistream === false) {
       await Promise.race([
-        this.multiStream(stream).finally(() => {
+        this.singleStream(stream).finally(() => {
           this.clearConnectionTimeout()
           this.clearMonitorSignalingWebSocketEvent()
         }),
@@ -30,7 +31,7 @@ export default class ConnectionPublisher extends ConnectionBase {
       ])
     } else {
       await Promise.race([
-        this.singleStream(stream).finally(() => {
+        this.multiStream(stream).finally(() => {
           this.clearConnectionTimeout()
           this.clearMonitorSignalingWebSocketEvent()
         }),

--- a/packages/sdk/src/sora.ts
+++ b/packages/sdk/src/sora.ts
@@ -82,14 +82,12 @@ class SoraConnection {
     metadata: JSONType = null,
     options: ConnectionOptions = { audio: true, video: true },
   ): ConnectionPublisher {
-    // sendrecv の場合、multistream に初期値を指定する
-    const sendrecvOptions: ConnectionOptions = Object.assign({ multistream: true }, options)
     return new ConnectionPublisher(
       this.signalingUrlCandidates,
       'sendrecv',
       channelId,
       metadata,
-      sendrecvOptions,
+      options,
       this.debug,
     )
   }

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -146,7 +146,8 @@ export function createSignalingMessage(
     video: true,
   }
   // role: sendrecv で multistream: false の場合は例外を発生させる
-  if (role === 'sendrecv' && options.multistream !== true) {
+  // options.multistream === undefined は multistream として扱う
+  if (role === 'sendrecv' && options.multistream === false) {
     throw new Error(
       "Failed to parse options. Options multistream must be true when connecting using 'sendrecv'",
     )

--- a/packages/sdk/tests/utils.test.ts
+++ b/packages/sdk/tests/utils.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from 'vitest'
-import { createSignalingMessage } from '../src/utils'
+import { expect, test } from 'vitest'
 import { type AudioCodecType, DataChannelDirection, VideoCodecType } from '../src/types'
+import { createSignalingMessage } from '../src/utils'
 
 const channelId = '7N3fsMHob'
 const metadata = 'PG9A6RXgYqiqWKOVO'
@@ -47,6 +47,15 @@ test('createSignalingMessage simple sendrecv', () => {
   ).toEqual(expectedMessage)
 })
 
+test('createSignalingMessage sendrecv and undefined multistream', () => {
+  const expectedMessage = Object.assign({}, baseExpectedMessage, {
+    role: 'sendrecv',
+  })
+  expect(createSignalingMessage(sdp, 'sendrecv', channelId, undefined, {}, false)).toEqual(
+    expectedMessage,
+  )
+})
+
 test('createSignalingMessage invalid role', () => {
   expect(() => {
     createSignalingMessage(sdp, 'test', channelId, metadata, {}, false)
@@ -55,7 +64,7 @@ test('createSignalingMessage invalid role', () => {
 
 test('createSignalingMessage sendrecv and multistream: false', () => {
   expect(() => {
-    createSignalingMessage(sdp, 'sendrecv', channelId, metadata, {}, false)
+    createSignalingMessage(sdp, 'sendrecv', channelId, metadata, { multistream: false }, false)
   }).toThrow(
     Error(
       "Failed to parse options. Options multistream must be true when connecting using 'sendrecv'",
@@ -135,6 +144,14 @@ test('createSignalingMessage multistream: true', () => {
   const expectedMessage = Object.assign({}, baseExpectedMessage, {
     multistream: options.multistream,
   })
+  expect(createSignalingMessage(sdp, 'sendonly', channelId, undefined, options, false)).toEqual(
+    expectedMessage,
+  )
+})
+
+test('createSignalingMessage undefined multistream', () => {
+  const options = {}
+  const expectedMessage = Object.assign({}, baseExpectedMessage, {})
   expect(createSignalingMessage(sdp, 'sendonly', channelId, undefined, options, false)).toEqual(
     expectedMessage,
   )


### PR DESCRIPTION
## 変更履歴

- [CHANGE] シグナリングオプションの `multistream` は false の時のみシングルストリームを使用する
  - シングルストリームを使用したい場合は `multistream: false` の指定が必須となる
  - @tnamao
