### PR TITLE
Feature/timeline signaling notify

### DIFF
--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -1237,7 +1237,7 @@ export default class ConnectionBase {
         } else if (message.type === 'push') {
           this.callbacks.push(message, 'websocket')
         } else if (message.type === 'notify') {
-                  // type: notify は全てタイムラインに記録する
+          // type: notify は全てタイムラインに記録する
           this.writeWebSocketTimelineLog(`${message.type}-${message.event_type}`, message)
           this.signalingOnMessageTypeNotify(message, 'websocket')
         } else if (message.type === 'switched') {


### PR DESCRIPTION
This pull request includes changes to the `ConnectionBase` class in `packages/sdk/src/base.ts` to simplify the logging of 'notify' events. Instead of logging only 'connection.created' and 'connection.destroyed' events, the updated code logs all 'notify' events to the timeline. 

* [`packages/sdk/src/base.ts`](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L1240-R1241): Simplified the logging of 'notify' events in the `ConnectionBase` class. All 'notify' events are now logged to the timeline, replacing the previous selective logging of 'connection.created' and 'connection.destroyed' events. [[1]](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L1240-R1241) [[2]](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L2190-R2192)