### PR TITLE
messaging のテスト項目を修正する ( ２つ目の bytesSent を削除 )

### DIFF
--- a/tests/messaging.spec.ts
+++ b/tests/messaging.spec.ts
@@ -102,7 +102,6 @@ test('messaging pages', async ({ browser }) => {
   expect(page1ExampleStats).toBeDefined()
   expect(page1ExampleStats?.messagesSent).toBeGreaterThan(0)
   expect(page1ExampleStats?.bytesSent).toBeGreaterThan(0)
-  expect(page1ExampleStats?.packetsSent).toBeGreaterThan(0)
   expect(page1ExampleStats?.messagesSent).toBeGreaterThan(0)
 
   // 統計情報が表示されるまで待機

--- a/tests/messaging.spec.ts
+++ b/tests/messaging.spec.ts
@@ -102,7 +102,7 @@ test('messaging pages', async ({ browser }) => {
   expect(page1ExampleStats).toBeDefined()
   expect(page1ExampleStats?.messagesSent).toBeGreaterThan(0)
   expect(page1ExampleStats?.bytesSent).toBeGreaterThan(0)
-  expect(page1ExampleStats?.bytesSent).toBeGreaterThan(0)
+  expect(page1ExampleStats?.packetsSent).toBeGreaterThan(0)
   expect(page1ExampleStats?.messagesSent).toBeGreaterThan(0)
 
   // 統計情報が表示されるまで待機


### PR DESCRIPTION
# 変更履歴

- E2E テストのうち messaging のテスト項目誤りを１つ修正する
  - bytesSent の２行目を削除する
 
