### PR TITLE
biome lint の対応をする

### DIFF
--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -91,8 +91,7 @@ export default class ConnectionBase {
   /**
    * PeerConnection に渡す configuration
    */
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  constraints: any
+  constraints: unknown
   /**
    * デバッグフラグ
    */
@@ -1919,10 +1918,9 @@ export default class ConnectionBase {
       return stats
     }
     const reports = await this.pc.getStats()
-    // biome-ignore lint/complexity/noForEach: RTCStatsReport であって Array ではない
-    reports.forEach((s) => {
-      stats.push(s as RTCStatsReport)
-    })
+    for (const [_, s] of reports.entries()) {
+      stats.push(s)
+    }
     return stats
   }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -349,8 +349,7 @@ export type TimelineEventLogType = 'websocket' | 'datachannel' | 'peerconnection
 
 export interface SignalingEvent extends Event {
   transportType: TransportType
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  data?: any
+  data?: unknown
 }
 
 export interface DataChannelMessageEvent extends Event {
@@ -364,8 +363,7 @@ export interface DataChannelEvent extends Event {
 
 export interface TimelineEvent extends Event {
   logType: TimelineEventLogType
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  data?: any
+  data?: unknown
   dataChannelId?: number | null
   dataChannelLabel?: string
 }


### PR DESCRIPTION
This pull request includes several changes aimed at improving type safety and code clarity in the `packages/sdk` module. The most important changes involve replacing the `any` type with `unknown` and refactoring a loop to enhance readability and maintainability.

Type safety improvements:

* [`packages/sdk/src/base.ts`](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L94-R94): Changed the type of the `constraints` property from `any` to `unknown` in the `ConnectionBase` class.
* [`packages/sdk/src/types.ts`](diffhunk://#diff-9d8c1fba9e81b9e94776fadecf0793c4bbacdf4474689eb6817576f5f7e6b5a8L352-R352): Updated the `data` property type from `any` to `unknown` in the `SignalingEvent` interface.
* [`packages/sdk/src/types.ts`](diffhunk://#diff-9d8c1fba9e81b9e94776fadecf0793c4bbacdf4474689eb6817576f5f7e6b5a8L367-R366): Modified the `data` property type from `any` to `unknown` in the `TimelineEvent` interface.

Code readability improvements:

* [`packages/sdk/src/base.ts`](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L1922-R1923): Refactored the loop in the `getStats` method to use `for...of` instead of `forEach`, improving readability and compatibility with `RTCStatsReport`.