### PR TITLE
addstream / removestream コールバックを削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] ブラウザでは非推奨となっている `addstream` と `removestream` コールバックを削除する
+  - 廃止宣言から 4 年位経過した
+  - @voluntas
 - [CHANGE] メッセージングを送信する `sendMessage` が `void` ではなく `Promise<void>` を返すようになりました
   - DataChannel の切断部分のロジックを大幅に書き換えた
   - 複数回 Disconnect を呼んだときの挙動に懸念あり

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -246,9 +246,7 @@ export default class ConnectionBase {
     this.callbacks = {
       disconnect: (): void => {},
       push: (): void => {},
-      addstream: (): void => {},
       track: (): void => {},
-      removestream: (): void => {},
       removetrack: (): void => {},
       notify: (): void => {},
       log: (): void => {},
@@ -284,27 +282,12 @@ export default class ConnectionBase {
    * });
    * ```
    *
-   * @remarks
-   * addstream イベントは非推奨です. track イベントを使用してください
-   *
-   * removestream イベントは非推奨です. removetrack イベントを使用してください
-   *
    * @param kind - イベントの種類(disconnect, push, track, removetrack, notify, log, timeout, timeline, signaling, message, datachannel)
    * @param callback - コールバック関数
    *
    * @public
    */
   on<T extends keyof Callbacks, U extends Callbacks[T]>(kind: T, callback: U): void {
-    // @deprecated message
-    if (kind === 'addstream') {
-      console.warn(
-        '@deprecated addstream callback will be removed in a future version. Use track callback.',
-      )
-    } else if (kind === 'removestream') {
-      console.warn(
-        '@deprecated removestream callback will be removed in a future version. Use removetrack callback.',
-      )
-    }
     if (kind in this.callbacks) {
       this.callbacks[kind] = callback
     }
@@ -1847,7 +1830,7 @@ export default class ConnectionBase {
 
   /**
    * シグナリングサーバーから受け取った type update メッセージを処理をするメソッド
-   *
+   * @deprecated このメソッドは非推奨です。将来のバージョンで削除される可能性があります。
    * @param message - type update メッセージ
    */
   private async signalingOnMessageTypeUpdate(message: SignalingUpdateMessage): Promise<void> {

--- a/packages/sdk/src/publisher.ts
+++ b/packages/sdk/src/publisher.ts
@@ -106,23 +106,17 @@ export default class ConnectionPublisher extends ConnectionBase {
         stream.onremovetrack = (event): void => {
           this.callbacks.removetrack(event)
           if (event.target) {
-            // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-            const index = this.remoteConnectionIds.indexOf(event.target.id as string)
+            const streamId = (event.target as MediaStream).id
+            const index = this.remoteConnectionIds.indexOf(streamId)
             if (-1 < index) {
               delete this.remoteConnectionIds[index]
-              // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-              event.stream = event.target
-              this.callbacks.removestream(event)
             }
           }
         }
         if (-1 < this.remoteConnectionIds.indexOf(stream.id)) {
           return
         }
-        // @ts-ignore TODO(yuito): 最新ブラウザでは無くなった API だが後方互換のため残す
-        event.stream = stream
         this.remoteConnectionIds.push(stream.id)
-        this.callbacks.addstream(event)
       }
     }
     await this.setRemoteDescription(signalingMessage)

--- a/packages/sdk/src/subscriber.ts
+++ b/packages/sdk/src/subscriber.ts
@@ -75,24 +75,17 @@ export default class ConnectionSubscriber extends ConnectionBase {
         this.stream.onremovetrack = (event): void => {
           this.callbacks.removetrack(event)
           if (event.target) {
-            // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-            const targetId = event.target.id as string
-            const index = this.remoteConnectionIds.indexOf(targetId)
+            const streamId = (event.target as MediaStreamTrack).id
+            const index = this.remoteConnectionIds.indexOf(streamId)
             if (-1 < index) {
               delete this.remoteConnectionIds[index]
-              // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-              event.stream = event.target
-              this.callbacks.removestream(event)
             }
           }
         }
         if (-1 < this.remoteConnectionIds.indexOf(streamId)) {
           return
         }
-        // @ts-ignore TODO(yuito): 最新ブラウザでは無くなった API だが後方互換のため残す
-        event.stream = this.stream
         this.remoteConnectionIds.push(streamId)
-        this.callbacks.addstream(event)
       }
     }
     await this.setRemoteDescription(signalingMessage)
@@ -134,24 +127,17 @@ export default class ConnectionSubscriber extends ConnectionBase {
         stream.onremovetrack = (event): void => {
           this.callbacks.removetrack(event)
           if (event.target) {
-            // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-            const targetId = event.target.id as string
-            const index = this.remoteConnectionIds.indexOf(targetId)
+            const streamId = (event.target as MediaStream).id
+            const index = this.remoteConnectionIds.indexOf(streamId)
             if (-1 < index) {
               delete this.remoteConnectionIds[index]
-              // @ts-ignore TODO(yuito): 後方互換のため peerConnection.onremovestream と同じ仕様で残す
-              event.stream = event.target
-              this.callbacks.removestream(event)
             }
           }
         }
         if (-1 < this.remoteConnectionIds.indexOf(stream.id)) {
           return
         }
-        // @ts-ignore TODO(yuito): 最新ブラウザでは無くなった API だが後方互換のため残す
-        event.stream = stream
         this.remoteConnectionIds.push(stream.id)
-        this.callbacks.addstream(event)
       }
     }
     await this.setRemoteDescription(signalingMessage)

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -129,6 +129,7 @@ export type SignalingOfferMessage = {
   }
 }
 
+// @deprecated この型は非推奨です。将来のバージョンで削除される可能性があります。
 export type SignalingUpdateMessage = {
   type: 'update'
   sdp: string
@@ -312,7 +313,8 @@ export type ConnectionOptions = {
   simulcast?: boolean
   simulcastRid?: SimulcastRid
   clientId?: string
-  timeout?: number // deprecated option
+  // @deprecated このオプションは非推奨です。将来のバージョンで削除される可能性があります。
+  timeout?: number
   connectionTimeout?: number
   signalingNotifyMetadata?: JSONType
   dataChannelSignaling?: boolean
@@ -328,9 +330,7 @@ export type ConnectionOptions = {
 export type Callbacks = {
   disconnect: (event: SoraCloseEvent) => void
   push: (event: SignalingPushMessage, transportType: TransportType) => void
-  addstream: (event: RTCTrackEvent) => void
   track: (event: RTCTrackEvent) => void
-  removestream: (event: MediaStreamTrackEvent) => void
   removetrack: (event: MediaStreamTrackEvent) => void
   notify: (event: SignalingNotifyMessage, transportType: TransportType) => void
   log: (title: string, message: JSONType) => void


### PR DESCRIPTION
This pull request focuses on removing deprecated `addstream` and `removestream` callbacks and updating related logic across several files. Additionally, it includes marking certain methods and types as deprecated for future removal.

### Removal of Deprecated Callbacks:

* [`packages/sdk/src/base.ts`](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L249-L251): Removed `addstream` and `removestream` callbacks from the `ConnectionBase` class and updated the `on` method to eliminate deprecated warnings. [[1]](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L249-L251) [[2]](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L287-L307)
* [`packages/sdk/src/publisher.ts`](diffhunk://#diff-d014f27a3c9e4b450996866cd267577c04725f362c292c59fd489dc0e36678dbL109-L125): Updated `ConnectionPublisher` to remove logic related to the `addstream` and `removestream` callbacks.
* [`packages/sdk/src/subscriber.ts`](diffhunk://#diff-01a3431dab10fec98f08a915920f8f1d6d1e9b0c18cd97e2f98b0e7c99fcfc8aL78-L95): Updated `ConnectionSubscriber` to remove logic related to the `addstream` and `removestream` callbacks. [[1]](diffhunk://#diff-01a3431dab10fec98f08a915920f8f1d6d1e9b0c18cd97e2f98b0e7c99fcfc8aL78-L95) [[2]](diffhunk://#diff-01a3431dab10fec98f08a915920f8f1d6d1e9b0c18cd97e2f98b0e7c99fcfc8aL137-L154)

### Deprecation Notices:

* [`packages/sdk/src/base.ts`](diffhunk://#diff-86ad7bee77842a53889b523c02bd3e7f9f8ae37a165e88d106b85e17f98628f0L1850-R1833): Added a deprecation notice to the `signalingOnMessageTypeUpdate` method.
* [`packages/sdk/src/types.ts`](diffhunk://#diff-9d8c1fba9e81b9e94776fadecf0793c4bbacdf4474689eb6817576f5f7e6b5a8R132): Marked the `SignalingUpdateMessage` type and the `timeout` option in `ConnectionOptions` as deprecated. [[1]](diffhunk://#diff-9d8c1fba9e81b9e94776fadecf0793c4bbacdf4474689eb6817576f5f7e6b5a8R132) [[2]](diffhunk://#diff-9d8c1fba9e81b9e94776fadecf0793c4bbacdf4474689eb6817576f5f7e6b5a8L315-R317)

### Documentation Updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Updated the changelog to reflect the removal of `addstream` and `removestream` callbacks and the change in the return type of `sendMessage`.