### PR TITLE
Slack 通知を shiguredo/github-actions の slack-notify に切り替える

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,16 +47,17 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run test
 
-  slack_notify_failed:
+  slack_notify:
     needs: [ci]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/e2e-test-canary.yml
+++ b/.github/workflows/e2e-test-canary.yml
@@ -67,29 +67,17 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  # slack_notify_succeeded:
-  #   needs: [e2e-test]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: sora-js-sdk
-  #         SLACK_COLOR: good
-  #         SLACK_TITLE: Succeeded
-  #         SLACK_ICON_EMOJI: ":star-struck:"
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
+  slack_notify:
     needs: [e2e-test-canary]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/e2e-test-h265.yml
+++ b/.github/workflows/e2e-test-h265.yml
@@ -64,29 +64,17 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  # slack_notify_succeeded:
-  #   needs: [e2e-test]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: sora-js-sdk
-  #         SLACK_COLOR: good
-  #         SLACK_TITLE: Succeeded
-  #         SLACK_ICON_EMOJI: ":star-struck:"
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
+  slack_notify:
     needs: [e2e-test-h265]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/e2e-test-webkit.yml
+++ b/.github/workflows/e2e-test-webkit.yml
@@ -52,29 +52,17 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  # slack_notify_succeeded:
-  #   needs: [e2e-test]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: sora-js-sdk
-  #         SLACK_COLOR: good
-  #         SLACK_TITLE: Succeeded
-  #         SLACK_ICON_EMOJI: ":star-struck:"
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
+  slack_notify:
     needs: [e2e-test-webkit]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,29 +83,17 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  # slack_notify_succeeded:
-  #   needs: [e2e-test]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: sora-js-sdk
-  #         SLACK_COLOR: good
-  #         SLACK_TITLE: Succeeded
-  #         SLACK_ICON_EMOJI: ":star-struck:"
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
+  slack_notify:
     needs: [e2e-test]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/npm-pkg-e2e-test.yml
+++ b/.github/workflows/npm-pkg-e2e-test.yml
@@ -85,29 +85,17 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  # slack_notify_succeeded:
-  #   needs: [npm-pkg-e2e-test]
-  #   runs-on: ubuntu-24.04
-  #   if: success()
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_CHANNEL: sora-js-sdk
-  #         SLACK_COLOR: good
-  #         SLACK_TITLE: Succeeded
-  #         SLACK_ICON_EMOJI: ":star-struck:"
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  slack_notify_failed:
+  slack_notify:
     needs: [npm-pkg-e2e-test]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -83,16 +83,17 @@ jobs:
       - run: npm install -g npm@latest
       - run: npm publish --no-git-checks
 
-  slack_notify_failed:
+  slack_notify:
     needs: [npm-publish-canary, npm-publish]
-    runs-on: ubuntu-24.04
-    if: failure()
+    runs-on: ubuntu-slim
+    if: ${{ !cancelled() }}
+    permissions:
+      actions: read
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: sora-js-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Failed
-          SLACK_ICON_EMOJI: ":japanese_ogre:"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          notify_mode: failure_and_fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
   - @voluntas
 - [CHANGE] E2E テストの環境変数の Prefix を `TEST_` に切り替える
   - @voluntas
+- [CHANGE] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に切り替える
+  - @voluntas
 
 ## 2025.2.0
 


### PR DESCRIPTION
## Summary

- Slack 通知を `rtCamp/action-slack-notify@v2` から `shiguredo/github-actions/.github/actions/slack-notify@main` に切り替える
- `notify_mode: failure_and_fixed` により失敗通知に加えて復旧 (Fixed) 通知に対応
- コメントアウトされていた成功通知ジョブを削除

## 対象ワークフロー

- ci.yaml
- e2e-test.yml
- e2e-test-canary.yml
- e2e-test-h265.yml
- e2e-test-webkit.yml
- npm-pkg-e2e-test.yml
- npm-publish.yml