### PR TITLE
e2e-test 失敗時に Claude による解析結果を Slack に通知する

### DIFF
--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -19,10 +19,13 @@ from typing import Any
 
 from anthropic import Anthropic
 
-LOG_TAIL_LINES = 300
+LOG_TAIL_LINES = 100
 HISTORY_LIMIT = 20
 DEFAULT_MODEL = "claude-sonnet-4-6"
 MAX_TOKENS = 2048
+# matrix が大きいときに全セルのログを送ると prompt が肥大化するため、
+# 失敗ジョブのうち最初の N 件だけログを取得し、残りはジョブ名だけ列挙する
+MAX_LOG_JOBS = 5
 
 SYSTEM_PROMPT = """\
 あなたは GitHub Actions の e2e-test の失敗を解析する。
@@ -224,7 +227,13 @@ def main() -> int:
     model = env("ANTHROPIC_MODEL", DEFAULT_MODEL)
 
     failed_jobs = collect_jobs(repo, run_id)
-    logs = {job["name"]: collect_log_tail(repo, job["id"]) for job in failed_jobs}
+    # 大量の matrix セル失敗時に prompt が肥大化するのを防ぐため、ログは先頭 MAX_LOG_JOBS 件だけ取得する
+    logs: dict[str, str] = {}
+    for i, job in enumerate(failed_jobs):
+        if i < MAX_LOG_JOBS:
+            logs[job["name"]] = collect_log_tail(repo, job["id"])
+        else:
+            logs[job["name"]] = "(log omitted; same failure pattern expected)"
     history = collect_history(repo, workflow, branch)
     recent_changes = collect_recent_changes()
 

--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -9,26 +9,106 @@
 入力は環境変数経由で受け取る。出力は stdout に JSON 1 オブジェクト。
 """
 
-from __future__ import annotations
-
 import json
 import os
 import subprocess
 import sys
-from typing import Any
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final, Literal, TypedDict, cast
 
 from anthropic import Anthropic
+from anthropic.types import TextBlock
 
-LOG_TAIL_LINES = 100
-HISTORY_LIMIT = 20
-DEFAULT_MODEL = "claude-sonnet-4-6"
-MAX_TOKENS = 2048
+LOG_TAIL_LINES: Final = 100
+HISTORY_LIMIT: Final = 20
+DEFAULT_MODEL: Final = "claude-sonnet-4-6"
+MAX_TOKENS: Final = 2048
 # matrix が大きいときに全セルのログを送ると prompt が肥大化するため、
 # 失敗ジョブのうち最初の N 件だけログを取得し、残りはジョブ名だけ列挙する
-MAX_LOG_JOBS = 5
+MAX_LOG_JOBS: Final = 5
 # 外部呼び出しが暴走しないようにそれぞれの上限を設ける (実測は API ~14s, gh 各 ~1s)
-ANTHROPIC_TIMEOUT_SEC = 60.0
-SUBPROCESS_TIMEOUT_SEC = 30
+ANTHROPIC_TIMEOUT_SEC: Final = 60.0
+SUBPROCESS_TIMEOUT_SEC: Final = 30
+
+JobConclusion = Literal["failure", "cancelled"]
+
+type JsonDict = dict[str, object]
+
+
+def _as_object_dict(value: object) -> JsonDict | None:
+    """JSON 由来の dict を JsonDict として扱う。"""
+    if not isinstance(value, dict):
+        return None
+    return cast(JsonDict, value)
+
+
+class FailureCategory(StrEnum):
+    FLAKY = "flaky"
+    EXTERNAL_DEPENDENCY = "external_dependency"
+    CODE_ISSUE = "code_issue"
+    INFRASTRUCTURE = "infrastructure"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+
+
+class Confidence(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class FailedStep(TypedDict):
+    name: str
+    conclusion: str | None
+    number: int | None
+
+
+class FailedJob(TypedDict):
+    id: int
+    name: str
+    conclusion: JobConclusion
+    started_at: str | None
+    completed_at: str | None
+    failed_steps: list[FailedStep]
+
+
+class RunHistoryEntry(TypedDict):
+    databaseId: int
+    conclusion: str | None
+    status: str
+    createdAt: str
+    headSha: str
+    event: str
+
+
+class AnalysisResult(TypedDict):
+    category: str
+    confidence: str
+    summary: str
+    evidence: str
+    suggested_action: str
+    affected_matrix: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class RunMeta:
+    run_id: str
+    workflow: str
+    branch: str
+    event: str
+    sha: str
+    e2e_test_result: str
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisContext:
+    meta: RunMeta
+    failed_jobs: list[FailedJob]
+    history: list[RunHistoryEntry]
+    recent_changes: str
+    logs: dict[str, str]
+
 
 SYSTEM_PROMPT = """\
 あなたは GitHub Actions の e2e-test の失敗を解析する。
@@ -70,6 +150,8 @@ SYSTEM_PROMPT = """\
 - 推測でカテゴリを決めないこと。証拠が薄ければ confidence: low か category: unknown。
 """
 
+_ANALYSIS_REQUIRED_KEYS = frozenset(AnalysisResult.__annotations__)
+
 
 def env(name: str, default: str | None = None) -> str:
     """環境変数を取得する。未設定なら default、それも無ければ KeyError。"""
@@ -82,12 +164,56 @@ def env(name: str, default: str | None = None) -> str:
 def run(*args: str, check: bool = True) -> str:
     """subprocess.run のラッパー。stdout を str で返す。"""
     result = subprocess.run(
-        args, capture_output=True, text=True, check=check, timeout=SUBPROCESS_TIMEOUT_SEC
+        args,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
     )
     return result.stdout
 
 
-def collect_jobs(repo: str, run_id: str) -> list[dict[str, Any]]:
+def _parse_failed_job(job: JsonDict) -> FailedJob | None:
+    conclusion = job.get("conclusion")
+    if conclusion not in ("failure", "cancelled"):
+        return None
+    job_id = job.get("id")
+    if not isinstance(job_id, int):
+        return None
+    name = job.get("name")
+    if not isinstance(name, str):
+        return None
+
+    steps = job.get("steps", [])
+    failed_steps: list[FailedStep] = []
+    if isinstance(steps, list):
+        for step_raw in steps:
+            step = _as_object_dict(step_raw)
+            if step is None:
+                continue
+            step_conclusion = step.get("conclusion")
+            if step_conclusion not in ("failure", "cancelled"):
+                continue
+            step_name = step.get("name")
+            step_number = step.get("number")
+            failed_steps.append(
+                {
+                    "name": str(step_name) if step_name is not None else "",
+                    "conclusion": str(step_conclusion) if step_conclusion else None,
+                    "number": step_number if isinstance(step_number, int) else None,
+                }
+            )
+    return {
+        "id": job_id,
+        "name": name,
+        "conclusion": cast(JobConclusion, conclusion),
+        "started_at": str(job["started_at"]) if job.get("started_at") else None,
+        "completed_at": str(job["completed_at"]) if job.get("completed_at") else None,
+        "failed_steps": failed_steps,
+    }
+
+
+def collect_jobs(repo: str, run_id: str) -> list[FailedJob]:
     """対象 run の失敗・キャンセルしたジョブ一覧を返す。"""
     raw = run(
         "gh",
@@ -97,30 +223,16 @@ def collect_jobs(repo: str, run_id: str) -> list[dict[str, Any]]:
         "--jq",
         ".jobs[]",
     )
-    failed: list[dict[str, Any]] = []
+    failed: list[FailedJob] = []
     for line in raw.splitlines():
         if not line.strip():
             continue
-        job = json.loads(line)
-        if job.get("conclusion") in ("failure", "cancelled"):
-            failed.append(
-                {
-                    "id": job["id"],
-                    "name": job["name"],
-                    "conclusion": job["conclusion"],
-                    "started_at": job.get("started_at"),
-                    "completed_at": job.get("completed_at"),
-                    "failed_steps": [
-                        {
-                            "name": s["name"],
-                            "conclusion": s.get("conclusion"),
-                            "number": s.get("number"),
-                        }
-                        for s in job.get("steps", [])
-                        if s.get("conclusion") in ("failure", "cancelled")
-                    ],
-                }
-            )
+        job = _as_object_dict(json.loads(line))
+        if job is None:
+            continue
+        parsed = _parse_failed_job(job)
+        if parsed is not None:
+            failed.append(parsed)
     return failed
 
 
@@ -136,7 +248,7 @@ def collect_log_tail(repo: str, job_id: int) -> str:
     return "\n".join(lines[-LOG_TAIL_LINES:])
 
 
-def collect_history(repo: str, workflow: str, branch: str) -> list[dict[str, Any]]:
+def collect_history(repo: str, workflow: str, branch: str) -> list[RunHistoryEntry]:
     """直近 N 回の同 workflow / 同 branch の実行履歴を返す。"""
     raw = run(
         "gh",
@@ -153,7 +265,7 @@ def collect_history(repo: str, workflow: str, branch: str) -> list[dict[str, Any
         "--json",
         "databaseId,conclusion,status,createdAt,headSha,event",
     )
-    return json.loads(raw)
+    return cast(list[RunHistoryEntry], json.loads(raw))
 
 
 def collect_recent_changes() -> str:
@@ -170,34 +282,79 @@ def collect_recent_changes() -> str:
             "e2e-tests/",
             "playwright.config.ts",
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    # PEP 758: except 句の括弧は省略可能
+    except subprocess.CalledProcessError, subprocess.TimeoutExpired:
         return ""
 
 
-def build_user_message(context: dict[str, Any]) -> str:
+def build_user_message(context: AnalysisContext) -> str:
     """Claude に渡す user message を組み立てる。"""
-    parts: list[str] = []
-
-    parts.append("# meta")
-    parts.append(json.dumps(context["meta"], indent=2, ensure_ascii=False))
-
-    parts.append("\n# failed_jobs")
-    parts.append(json.dumps(context["failed_jobs"], indent=2, ensure_ascii=False))
-
-    parts.append(f"\n# history (直近 {HISTORY_LIMIT} 回)")
-    parts.append(json.dumps(context["history"], indent=2, ensure_ascii=False))
-
-    parts.append("\n# recent_changes (直近 5 コミットの e2e-tests/ 配下)")
-    parts.append(context["recent_changes"] or "(変更なし)")
-
-    parts.append("\n# logs (各失敗ジョブのログ末尾)")
-    for name, log in context["logs"].items():
+    meta = {
+        "run_id": context.meta.run_id,
+        "workflow": context.meta.workflow,
+        "branch": context.meta.branch,
+        "event": context.meta.event,
+        "sha": context.meta.sha,
+        "e2e_test_result": context.meta.e2e_test_result,
+    }
+    parts = [
+        "# meta",
+        json.dumps(meta, indent=2, ensure_ascii=False),
+        "\n# failed_jobs",
+        json.dumps(context.failed_jobs, indent=2, ensure_ascii=False),
+        f"\n# history (直近 {HISTORY_LIMIT} 回)",
+        json.dumps(context.history, indent=2, ensure_ascii=False),
+        "\n# recent_changes (直近 5 コミットの e2e-tests/ 配下)",
+        context.recent_changes or "(変更なし)",
+        "\n# logs (各失敗ジョブのログ末尾)",
+    ]
+    for name, log in context.logs.items():
         parts.append(f"\n--- {name} ---\n{log}")
-
     return "\n".join(parts)
 
 
-def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any]:
+def _extract_json_object(body: str) -> dict[str, object]:
+    """レスポンス本文から最初の JSON オブジェクトを抽出する。"""
+    start = body.find("{")
+    end = body.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"no JSON object found in response: {body!r}")
+    parsed = json.loads(body[start : end + 1])
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected JSON object, got {type(parsed).__name__}")
+    return parsed
+
+
+def _coerce_analysis(raw: dict[str, object]) -> AnalysisResult:
+    """API 応答を AnalysisResult に正規化する。未知の category は unknown に落とす。"""
+    missing = _ANALYSIS_REQUIRED_KEYS - raw.keys()
+    if missing:
+        raise ValueError(f"analysis missing keys: {sorted(missing)}")
+
+    category = str(raw["category"])
+    if category not in FailureCategory:
+        category = FailureCategory.UNKNOWN
+
+    confidence = str(raw["confidence"])
+    if confidence not in Confidence:
+        confidence = Confidence.LOW
+
+    affected = raw["affected_matrix"]
+    if not isinstance(affected, list):
+        raise ValueError("affected_matrix must be a list")
+    affected_matrix = [str(item) for item in affected]
+
+    return {
+        "category": category,
+        "confidence": confidence,
+        "summary": str(raw["summary"]),
+        "evidence": str(raw["evidence"]),
+        "suggested_action": str(raw["suggested_action"]),
+        "affected_matrix": affected_matrix,
+    }
+
+
+def call_anthropic(api_key: str, model: str, user_message: str) -> AnalysisResult:
     """Messages API を呼び、レスポンスから JSON を抽出して返す。
 
     claude-sonnet-4-6 は assistant message prefill をサポートしないため、
@@ -208,18 +365,13 @@ def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any
         model=model,
         max_tokens=MAX_TOKENS,
         system=SYSTEM_PROMPT,
-        messages=[
-            {"role": "user", "content": user_message},
-        ],
+        messages=[{"role": "user", "content": user_message}],
     )
 
-    body = response.content[0].text
-    # コードフェンスやチャット応答の前後を吸収して JSON を抽出する
-    start = body.find("{")
-    end = body.rfind("}")
-    if start == -1 or end == -1 or end <= start:
-        raise ValueError(f"no JSON object found in response: {body!r}")
-    return json.loads(body[start : end + 1])
+    block = response.content[0]
+    if not isinstance(block, TextBlock):
+        raise ValueError(f"unexpected content block type: {type(block).__name__}")
+    return _coerce_analysis(_extract_json_object(block.text))
 
 
 def main() -> int:
@@ -241,23 +393,21 @@ def main() -> int:
             logs[job["name"]] = collect_log_tail(repo, job["id"])
         else:
             logs[job["name"]] = "(log omitted; same failure pattern expected)"
-    history = collect_history(repo, workflow, branch)
-    recent_changes = collect_recent_changes()
 
-    context = {
-        "meta": {
-            "run_id": run_id,
-            "workflow": workflow,
-            "branch": branch,
-            "event": event_name,
-            "sha": sha,
-            "e2e_test_result": e2e_result,
-        },
-        "failed_jobs": failed_jobs,
-        "history": history,
-        "recent_changes": recent_changes,
-        "logs": logs,
-    }
+    context = AnalysisContext(
+        meta=RunMeta(
+            run_id=run_id,
+            workflow=workflow,
+            branch=branch,
+            event=event_name,
+            sha=sha,
+            e2e_test_result=e2e_result,
+        ),
+        failed_jobs=failed_jobs,
+        history=collect_history(repo, workflow, branch),
+        recent_changes=collect_recent_changes(),
+        logs=logs,
+    )
 
     user_message = build_user_message(context)
     print(f"=== user_message length: {len(user_message)} chars ===", file=sys.stderr)

--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -26,6 +26,9 @@ MAX_TOKENS = 2048
 # matrix が大きいときに全セルのログを送ると prompt が肥大化するため、
 # 失敗ジョブのうち最初の N 件だけログを取得し、残りはジョブ名だけ列挙する
 MAX_LOG_JOBS = 5
+# 外部呼び出しが暴走しないようにそれぞれの上限を設ける (実測は API ~14s, gh 各 ~1s)
+ANTHROPIC_TIMEOUT_SEC = 60.0
+SUBPROCESS_TIMEOUT_SEC = 30
 
 SYSTEM_PROMPT = """\
 あなたは GitHub Actions の e2e-test の失敗を解析する。
@@ -78,7 +81,9 @@ def env(name: str, default: str | None = None) -> str:
 
 def run(*args: str, check: bool = True) -> str:
     """subprocess.run のラッパー。stdout を str で返す。"""
-    result = subprocess.run(args, capture_output=True, text=True, check=check)
+    result = subprocess.run(
+        args, capture_output=True, text=True, check=check, timeout=SUBPROCESS_TIMEOUT_SEC
+    )
     return result.stdout
 
 
@@ -120,11 +125,13 @@ def collect_jobs(repo: str, run_id: str) -> list[dict[str, Any]]:
 
 
 def collect_log_tail(repo: str, job_id: int) -> str:
-    """ジョブのログ末尾を返す。取得失敗時は (log fetch failed) を返す。"""
+    """ジョブのログ末尾を返す。取得失敗・タイムアウト時は理由付きで返す。"""
     try:
         log = run("gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs")
     except subprocess.CalledProcessError:
         return "(log fetch failed)"
+    except subprocess.TimeoutExpired:
+        return f"(log fetch timed out after {SUBPROCESS_TIMEOUT_SEC}s)"
     lines = log.splitlines()
     return "\n".join(lines[-LOG_TAIL_LINES:])
 
@@ -163,7 +170,7 @@ def collect_recent_changes() -> str:
             "e2e-tests/",
             "playwright.config.ts",
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return ""
 
 
@@ -196,7 +203,7 @@ def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any
     claude-sonnet-4-6 は assistant message prefill をサポートしないため、
     レスポンス本文から最初の `{` 〜 最後の `}` までを抽出して JSON としてパースする。
     """
-    client = Anthropic(api_key=api_key)
+    client = Anthropic(api_key=api_key, timeout=ANTHROPIC_TIMEOUT_SEC)
     response = client.messages.create(
         model=model,
         max_tokens=MAX_TOKENS,

--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -1,7 +1,7 @@
 # /// script
-# requires-python = ">=3.13"
+# requires-python = ">=3.14"
 # dependencies = [
-#   "anthropic>=0.50.0",
+#   "anthropic>=0.103.0",
 # ]
 # ///
 """e2e-test の失敗を Anthropic Messages API で解析し、JSON を stdout に出力する。

--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -188,7 +188,11 @@ def build_user_message(context: dict[str, Any]) -> str:
 
 
 def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any]:
-    """Messages API を呼び、prefill で JSON を強制取得する。"""
+    """Messages API を呼び、レスポンスから JSON を抽出して返す。
+
+    claude-sonnet-4-6 は assistant message prefill をサポートしないため、
+    レスポンス本文から最初の `{` 〜 最後の `}` までを抽出して JSON としてパースする。
+    """
     client = Anthropic(api_key=api_key)
     response = client.messages.create(
         model=model,
@@ -196,23 +200,16 @@ def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any
         system=SYSTEM_PROMPT,
         messages=[
             {"role": "user", "content": user_message},
-            {"role": "assistant", "content": "{"},
         ],
     )
 
-    # prefill した `{` を補って完全な JSON にする
     body = response.content[0].text
-    raw = "{" + body
-    # まれに ```json などで包まれた場合のフォールバック
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        # 最初の { から最後の } までを切り出して再試行
-        start = raw.find("{")
-        end = raw.rfind("}")
-        if start != -1 and end != -1 and end > start:
-            return json.loads(raw[start : end + 1])
-        raise
+    # コードフェンスやチャット応答の前後を吸収して JSON を抽出する
+    start = body.find("{")
+    end = body.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(f"no JSON object found in response: {body!r}")
+    return json.loads(body[start : end + 1])
 
 
 def main() -> int:

--- a/.github/scripts/analyze_e2e_failure.py
+++ b/.github/scripts/analyze_e2e_failure.py
@@ -1,0 +1,258 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "anthropic>=0.50.0",
+# ]
+# ///
+"""e2e-test の失敗を Anthropic Messages API で解析し、JSON を stdout に出力する。
+
+入力は環境変数経由で受け取る。出力は stdout に JSON 1 オブジェクト。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+from anthropic import Anthropic
+
+LOG_TAIL_LINES = 300
+HISTORY_LIMIT = 20
+DEFAULT_MODEL = "claude-sonnet-4-6"
+MAX_TOKENS = 2048
+
+SYSTEM_PROMPT = """\
+あなたは GitHub Actions の e2e-test の失敗を解析する。
+
+## 入力
+ユーザーメッセージにメタ情報・失敗ジョブ・直近実行履歴・直近のコード変更・各失敗ジョブのログ末尾が
+セクション分けされて与えられる。
+
+## 出力
+以下の構造で 1 つの JSON オブジェクトだけを出力する。前後に説明文・コードフェンスは一切付けない。
+
+{
+  "category": "flaky | external_dependency | code_issue | infrastructure | cancelled | unknown",
+  "confidence": "low | medium | high",
+  "summary": "1-2 文の日本語要約",
+  "evidence": "判定根拠 (どのログのどの行か、何回中何回失敗しているか)",
+  "suggested_action": "次の一手 (1 文、日本語)",
+  "affected_matrix": ["ubuntu-24.04 / node-22 / Google Chrome", "..."]
+}
+
+## 判定指針
+- flaky: 同じ matrix セルが直近 20 回で成功と失敗を混在させている (失敗率 5-50% 程度)。
+  または「タイムアウトのみが原因」かつ「他セルは成功」。
+- external_dependency: ログに以下のパターンが見える場合
+  - Tailscale 関連エラー (`tailscale`, `ts.net`, `ping failed`)
+  - Signaling/API URL への接続失敗 (`ECONNREFUSED`, `ETIMEDOUT`, `net::ERR_`, `getaddrinfo`)
+  - Playwright ブラウザのダウンロード失敗
+  - npm/pnpm レジストリエラー
+- code_issue: Playwright のアサーション失敗 (`expect(...).toBe...`, `Timed out waiting for`) が安定再現していて、
+  直近の `e2e-tests/` 配下に変更がある場合は confidence high。変更が無い場合は medium。
+- infrastructure: runner の OOM, disk full, GitHub Actions 側の障害。
+- cancelled: 全ジョブが cancelled で上記いずれにも該当しない。
+- unknown: 判定材料が不足、または上記のいずれにも明確に該当しない。
+
+## 注意
+- affected_matrix は `<os> / node-<version> / <browser>` 形式で、失敗したセルだけを列挙する。
+- summary は実装者がパッと読んで分かる粒度で具体的に書く。
+- suggested_action は「再実行で様子見」「Tailscale の状態確認」「コード修正、テスト X 確認」のように行動可能な表現。
+- 推測でカテゴリを決めないこと。証拠が薄ければ confidence: low か category: unknown。
+"""
+
+
+def env(name: str, default: str | None = None) -> str:
+    """環境変数を取得する。未設定なら default、それも無ければ KeyError。"""
+    value = os.environ.get(name, default)
+    if value is None:
+        raise KeyError(f"environment variable {name!r} is required")
+    return value
+
+
+def run(*args: str, check: bool = True) -> str:
+    """subprocess.run のラッパー。stdout を str で返す。"""
+    result = subprocess.run(args, capture_output=True, text=True, check=check)
+    return result.stdout
+
+
+def collect_jobs(repo: str, run_id: str) -> list[dict[str, Any]]:
+    """対象 run の失敗・キャンセルしたジョブ一覧を返す。"""
+    raw = run(
+        "gh",
+        "api",
+        f"repos/{repo}/actions/runs/{run_id}/jobs",
+        "--paginate",
+        "--jq",
+        ".jobs[]",
+    )
+    failed: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        job = json.loads(line)
+        if job.get("conclusion") in ("failure", "cancelled"):
+            failed.append(
+                {
+                    "id": job["id"],
+                    "name": job["name"],
+                    "conclusion": job["conclusion"],
+                    "started_at": job.get("started_at"),
+                    "completed_at": job.get("completed_at"),
+                    "failed_steps": [
+                        {
+                            "name": s["name"],
+                            "conclusion": s.get("conclusion"),
+                            "number": s.get("number"),
+                        }
+                        for s in job.get("steps", [])
+                        if s.get("conclusion") in ("failure", "cancelled")
+                    ],
+                }
+            )
+    return failed
+
+
+def collect_log_tail(repo: str, job_id: int) -> str:
+    """ジョブのログ末尾を返す。取得失敗時は (log fetch failed) を返す。"""
+    try:
+        log = run("gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs")
+    except subprocess.CalledProcessError:
+        return "(log fetch failed)"
+    lines = log.splitlines()
+    return "\n".join(lines[-LOG_TAIL_LINES:])
+
+
+def collect_history(repo: str, workflow: str, branch: str) -> list[dict[str, Any]]:
+    """直近 N 回の同 workflow / 同 branch の実行履歴を返す。"""
+    raw = run(
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--workflow",
+        workflow,
+        "--branch",
+        branch,
+        "--limit",
+        str(HISTORY_LIMIT),
+        "--json",
+        "databaseId,conclusion,status,createdAt,headSha,event",
+    )
+    return json.loads(raw)
+
+
+def collect_recent_changes() -> str:
+    """直近 5 コミットの e2e-tests/ 配下と playwright.config.ts の変更を返す。"""
+    try:
+        return run(
+            "git",
+            "log",
+            "-5",
+            "--name-status",
+            "--pretty=format:commit %h %s%n%an %ad",
+            "--date=short",
+            "--",
+            "e2e-tests/",
+            "playwright.config.ts",
+        )
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def build_user_message(context: dict[str, Any]) -> str:
+    """Claude に渡す user message を組み立てる。"""
+    parts: list[str] = []
+
+    parts.append("# meta")
+    parts.append(json.dumps(context["meta"], indent=2, ensure_ascii=False))
+
+    parts.append("\n# failed_jobs")
+    parts.append(json.dumps(context["failed_jobs"], indent=2, ensure_ascii=False))
+
+    parts.append(f"\n# history (直近 {HISTORY_LIMIT} 回)")
+    parts.append(json.dumps(context["history"], indent=2, ensure_ascii=False))
+
+    parts.append("\n# recent_changes (直近 5 コミットの e2e-tests/ 配下)")
+    parts.append(context["recent_changes"] or "(変更なし)")
+
+    parts.append("\n# logs (各失敗ジョブのログ末尾)")
+    for name, log in context["logs"].items():
+        parts.append(f"\n--- {name} ---\n{log}")
+
+    return "\n".join(parts)
+
+
+def call_anthropic(api_key: str, model: str, user_message: str) -> dict[str, Any]:
+    """Messages API を呼び、prefill で JSON を強制取得する。"""
+    client = Anthropic(api_key=api_key)
+    response = client.messages.create(
+        model=model,
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        messages=[
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": "{"},
+        ],
+    )
+
+    # prefill した `{` を補って完全な JSON にする
+    body = response.content[0].text
+    raw = "{" + body
+    # まれに ```json などで包まれた場合のフォールバック
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        # 最初の { から最後の } までを切り出して再試行
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            return json.loads(raw[start : end + 1])
+        raise
+
+
+def main() -> int:
+    repo = env("GITHUB_REPOSITORY")
+    run_id = env("GITHUB_RUN_ID")
+    workflow = env("GITHUB_WORKFLOW")
+    branch = env("GITHUB_REF_NAME")
+    event_name = env("GITHUB_EVENT_NAME")
+    sha = env("GITHUB_SHA")
+    e2e_result = env("E2E_RESULT")
+    api_key = env("ANTHROPIC_API_KEY")
+    model = env("ANTHROPIC_MODEL", DEFAULT_MODEL)
+
+    failed_jobs = collect_jobs(repo, run_id)
+    logs = {job["name"]: collect_log_tail(repo, job["id"]) for job in failed_jobs}
+    history = collect_history(repo, workflow, branch)
+    recent_changes = collect_recent_changes()
+
+    context = {
+        "meta": {
+            "run_id": run_id,
+            "workflow": workflow,
+            "branch": branch,
+            "event": event_name,
+            "sha": sha,
+            "e2e_test_result": e2e_result,
+        },
+        "failed_jobs": failed_jobs,
+        "history": history,
+        "recent_changes": recent_changes,
+        "logs": logs,
+    }
+
+    user_message = build_user_message(context)
+    print(f"=== user_message length: {len(user_message)} chars ===", file=sys.stderr)
+
+    analysis = call_anthropic(api_key, model, user_message)
+    print(json.dumps(analysis, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -113,7 +113,9 @@ jobs:
         with:
           fetch-depth: 5
 
-      - uses: astral-sh/setup-uv@v8
+      # https://github.com/astral-sh/setup-uv/releases v8.0.0 以降は minor/major タグが
+      # 公開されないため、immutable tag (v8.1.0 相当の commit SHA) で固定する
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Analyze failure
         if: ${{ env.ANTHROPIC_API_KEY != '' }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -78,17 +78,130 @@ jobs:
       #     path: playwright-report/
       #     retention-days: 30
 
-  slack_notify:
+  # 成功時 (Fixed 含む) は解析不要なので軽量に通知する
+  slack_notify_fixed:
     needs: [e2e-test]
     runs-on: ubuntu-slim
-    if: ${{ !cancelled() }}
+    if: ${{ needs.e2e-test.result == 'success' }}
     permissions:
       actions: read
     steps:
       - name: Slack Notification
         uses: shiguredo/github-actions/.github/actions/slack-notify@main
         with:
-          status: ${{ job.status }}
+          status: success
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           slack_channel: sora-js-sdk
+          # status=success のとき failure_and_fixed は Fixed のみ通知し、
+          # 通常の success は自動でスキップされる
           notify_mode: failure_and_fixed
+
+  # 失敗・キャンセル時は Python スクリプトで Anthropic API を叩いて解析する
+  analyze_and_notify_failure:
+    needs: [e2e-test]
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.e2e-test.result == 'failure' || needs.e2e-test.result == 'cancelled') }}
+    permissions:
+      actions: read
+      contents: read
+    env:
+      # API キー未設定時に Analyze ステップをスキップするため job-level に上げる
+      # (step-level env は同じ step の if 式から参照できない)
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_SORA_OSS_SONNET }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
+
+      - uses: astral-sh/setup-uv@v8
+
+      - name: Analyze failure
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
+        id: analyze
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA: ${{ github.sha }}
+          E2E_RESULT: ${{ needs.e2e-test.result }}
+          ANTHROPIC_MODEL: claude-sonnet-4-6
+        run: |
+          set -euo pipefail
+          uv run .github/scripts/analyze_e2e_failure.py > /tmp/analysis.json
+          echo "=== analysis.json ==="
+          cat /tmp/analysis.json
+
+      - name: Build Slack payload
+        id: payload
+        run: |
+          set -euo pipefail
+
+          # 解析失敗時のフォールバック
+          if [[ ! -s /tmp/analysis.json ]]; then
+            echo "::warning::/tmp/analysis.json が見つからないか空。フォールバックで通知する"
+            cat > /tmp/analysis.json <<'EOF'
+          {
+            "category": "unknown",
+            "confidence": "low",
+            "summary": "自動解析に失敗。Actions のログを確認すること",
+            "evidence": "",
+            "suggested_action": "Actions のログを直接確認",
+            "affected_matrix": []
+          }
+          EOF
+          fi
+
+          CATEGORY=$(jq -r '.category // "unknown"' /tmp/analysis.json)
+          CONFIDENCE=$(jq -r '.confidence // "low"' /tmp/analysis.json)
+          SUMMARY=$(jq -r '.summary // ""' /tmp/analysis.json)
+          ACTION_HINT=$(jq -r '.suggested_action // ""' /tmp/analysis.json)
+          EVIDENCE=$(jq -r '.evidence // ""' /tmp/analysis.json)
+          AFFECTED=$(jq -r '.affected_matrix // [] | join(", ")' /tmp/analysis.json)
+
+          case "${CATEGORY}" in
+            code_issue)          COLOR="danger";  PREFIX="[code]" ;;
+            external_dependency) COLOR="warning"; PREFIX="[external]" ;;
+            infrastructure)      COLOR="warning"; PREFIX="[infra]" ;;
+            flaky)               COLOR="#FFA500"; PREFIX="[flaky]" ;;
+            cancelled)           COLOR="#808080"; PREFIX="[cancelled]" ;;
+            *)                   COLOR="#808080"; PREFIX="[unknown]" ;;
+          esac
+
+          MESSAGE="${SUMMARY}"
+          if [[ -n "${ACTION_HINT}" ]]; then
+            MESSAGE="${MESSAGE}"$'\n'"次の一手: ${ACTION_HINT}"
+          fi
+          if [[ -n "${EVIDENCE}" ]]; then
+            MESSAGE="${MESSAGE}"$'\n'"根拠: ${EVIDENCE}"
+          fi
+          if [[ -n "${AFFECTED}" ]]; then
+            MESSAGE="${MESSAGE}"$'\n'"影響: ${AFFECTED}"
+          fi
+          MESSAGE="${MESSAGE}"$'\n'"判定信頼度: ${CONFIDENCE}"
+
+          {
+            echo "color=${COLOR}"
+            echo "prefix=${PREFIX}"
+            echo "message<<__EOF__"
+            echo "${MESSAGE}"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "=== built message ==="
+          echo "${MESSAGE}"
+
+      - name: Slack Notification
+        uses: shiguredo/github-actions/.github/actions/slack-notify@main
+        with:
+          status: ${{ needs.e2e-test.result }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_channel: sora-js-sdk
+          slack_title: ${{ steps.payload.outputs.prefix }} e2e-test
+          slack_message: ${{ steps.payload.outputs.message }}
+          slack_color: ${{ steps.payload.outputs.color }}
+          notify_mode: failure_only
+          notify_cancelled: "true"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -99,7 +99,7 @@ jobs:
   # 失敗・キャンセル時は Python スクリプトで Anthropic API を叩いて解析する
   analyze_and_notify_failure:
     needs: [e2e-test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # 解析の暴走・API ハング・gh CLI ハングなどから守るための hard ceiling
     # (実測値は約 25 秒なので 5 分は十分な余裕がある)
     timeout-minutes: 5
@@ -119,6 +119,8 @@ jobs:
       # https://github.com/astral-sh/setup-uv/releases v8.0.0 以降は minor/major タグが
       # 公開されないため、immutable tag (v8.1.0 相当の commit SHA) で固定する
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.14"
 
       - name: Analyze failure
         if: ${{ env.ANTHROPIC_API_KEY != '' }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -100,6 +100,9 @@ jobs:
   analyze_and_notify_failure:
     needs: [e2e-test]
     runs-on: ubuntu-latest
+    # 解析の暴走・API ハング・gh CLI ハングなどから守るための hard ceiling
+    # (実測値は約 25 秒なので 5 分は十分な余裕がある)
+    timeout-minutes: 5
     if: ${{ always() && (needs.e2e-test.result == 'failure' || needs.e2e-test.result == 'cancelled') }}
     permissions:
       actions: read
@@ -121,6 +124,7 @@ jobs:
         if: ${{ env.ANTHROPIC_API_KEY != '' }}
         id: analyze
         continue-on-error: true
+        timeout-minutes: 3
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ dist/
 .env*
 !.env.template
 
+# python
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
 # playwright
 /test-results/
 /playwright-report/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
   - @voluntas
 - [CHANGE] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に切り替える
   - @voluntas
+- [ADD] e2e-test の失敗・キャンセル時に Anthropic API で解析した結果を Slack に通知する
+  - @voluntas
 
 ## 2025.2.0
 

--- a/e2e-tests/tests/intentional_failure.test.ts
+++ b/e2e-tests/tests/intentional_failure.test.ts
@@ -1,7 +1,0 @@
-import { expect, test } from "@playwright/test";
-
-// analyze_and_notify_failure ジョブの動作確認用に意図的に失敗させるテスト
-// 確認が終わったら revert する
-test("intentional failure for analyzer", () => {
-  expect(true).toBe(false);
-});

--- a/e2e-tests/tests/intentional_failure.test.ts
+++ b/e2e-tests/tests/intentional_failure.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "@playwright/test";
+
+// analyze_and_notify_failure ジョブの動作確認用に意図的に失敗させるテスト
+// 確認が終わったら revert する
+test("intentional failure for analyzer", () => {
+  expect(true).toBe(false);
+});


### PR DESCRIPTION
## Summary

- `e2e-test` workflow に `analyze_and_notify_failure` ジョブを追加し、failure/cancelled 時に GitHub API でジョブ・ログ末尾・履歴・直近変更を収集して Anthropic Messages API で解析する
- 解析結果は category (flaky / external_dependency / code_issue / infrastructure / cancelled / unknown) + summary / suggested_action / evidence / affected_matrix を含む JSON で受け取り、category に応じた色とプレフィックスで Slack に通知する
- 既存 slack_notify は slack_notify_fixed に分離して Fixed 通知専用に変更
- 解析は Python (PEP 723 inline deps) + uv で実行、ジョブ 5 分 / ステップ 3 分 / API 60s / subprocess 30s の多層 timeout を設定

## Test plan

- [x] feature ブランチで意図的失敗テストを仕込み、run 26079673207 で動作確認済み
  - Claude が `category: code_issue` / `confidence: high` で判定
  - `affected_matrix` に 27 セル全列挙
  - Slack に `[code] e2e-test` で danger 色の通知が届く
- [ ] develop マージ後、次回 schedule で実際の失敗 (もしくは想定外の挙動) が起きたときの解析精度を確認
- [ ] 1-2 週間運用して category 判定の妥当性を評価