### PR TITLE
redirect / switched 受信時に旧 WebSocket のハンドラを解除してから close する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
   - @voluntas
 - [FIX] rpc メソッドのサンプルコードで、実際に存在しない RPC メソッド名が使われていたのを修正する
   - @sile
+- [FIX] type: redirect 受信時に旧 WebSocket の onmessage ハンドラが解除されていなかったのを修正する
+  - @voluntas
+- [FIX] type: switched (ignore_disconnect_websocket) 経路で旧 WebSocket の onmessage / onerror ハンドラが解除されていなかったのを修正する
+  - @voluntas
 
 ### misc
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -2045,6 +2045,8 @@ export default class ConnectionBase {
     if (message.ignore_disconnect_websocket) {
       if (this.ws) {
         this.ws.onclose = null;
+        this.ws.onmessage = null;
+        this.ws.onerror = null;
         this.ws.close();
         this.ws = null;
       }
@@ -2066,6 +2068,7 @@ export default class ConnectionBase {
   ): Promise<SignalingOfferMessage> {
     if (this.ws) {
       this.ws.onclose = null;
+      this.ws.onmessage = null;
       this.ws.onerror = null;
       this.ws.close();
       this.ws = null;


### PR DESCRIPTION
## 概要

type: redirect 受信時および type: switched (ignore_disconnect_websocket: true) 受信時に、旧 WebSocket のメッセージ系ハンドラを解除しないまま close していた問題を修正する。

## 変更内容

- signalingOnMessageTypeRedirect: ws.close() の前に this.ws.onmessage = null を追加
- signalingOnMessageTypeSwitched (ignore_disconnect_websocket: true): ws.close() の前に this.ws.onmessage = null と this.ws.onerror = null を追加
- handler 解除順序は onclose → onmessage → onerror → close() → this.ws = null

## 完了条件

- [x] signalingOnMessageTypeRedirect で ws.close() の前に this.ws.onmessage = null が追加されている
- [x] signalingOnMessageTypeSwitched の ignore_disconnect_websocket: true 経路で ws.close() の前に this.ws.onmessage / this.ws.onerror が追加されている
- [x] handler 解除順序が設計方針どおり
- [x] pnpm test 通過 (2 files, 72 tests)
- [x] CHANGES.md に FIX を追記

## 関連 issue

- issues/0001-bug-fix-redirect-old-ws-onmessage-not-cleared.md