### PR TITLE
0038 CI に @typescript/native-preview による型検証ジョブを追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,22 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run test
 
+  typescript-native-preview:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "26"
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm remove -D typescript -w
+      - run: pnpm add -E -D @typescript/native-preview -w
+      - run: pnpm exec tsgo --emitDeclarationOnly -p tsconfig.json
+      - run: pnpm exec tsgo --noEmit -p e2e-tests/tsconfig.json
+
   slack_notify:
-    needs: [ci]
+    needs: [ci, typescript-native-preview]
     runs-on: ubuntu-slim
     if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,11 @@ jobs:
 
   typescript-native-preview:
     runs-on: ubuntu-slim
+    strategy:
+      matrix:
+        version:
+          - "latest"
+          - "beta"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -55,7 +60,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - run: pnpm install --frozen-lockfile
       - run: pnpm remove -D typescript -w
-      - run: pnpm add -E -D @typescript/native-preview -w
+      - run: pnpm add -E -D @typescript/native-preview@${{ matrix.version }} -w
       - run: pnpm exec tsgo --emitDeclarationOnly -p tsconfig.json
       - run: pnpm exec tsgo --noEmit -p e2e-tests/tsconfig.json
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
   - @voluntas
 - [CHANGE] Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions の slack-notify に切り替える
   - @voluntas
+- [ADD] CI に @typescript/native-preview による型検証ジョブを追加する
+  - @voluntas
 - [UPDATE] e2e テストの Node バージョンを 22 / 24 / 26 に更新する
   - Node 25 を Node 26 (LTS) に置き換える
   - @voluntas

--- a/e2e-tests/data_channel_signaling_only/main.ts
+++ b/e2e-tests/data_channel_signaling_only/main.ts
@@ -55,7 +55,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/fake_sendonly/main.ts
+++ b/e2e-tests/fake_sendonly/main.ts
@@ -28,8 +28,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     client = new SoraClient(signalingUrl, channelId, secretKey);
 
-    const useFakeAudio = document.querySelector("#use-fake-audio")!.checked;
-    const useFakeVideo = document.querySelector("#use-fake-video")!.checked;
+    const useFakeAudio = document.querySelector<HTMLInputElement>("#use-fake-audio")!.checked;
+    const useFakeVideo = document.querySelector<HTMLInputElement>("#use-fake-video")!.checked;
 
     const stream = getFakeMedia({
       audio: useFakeAudio,
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/fake_stereo_audio/main.ts
+++ b/e2e-tests/fake_stereo_audio/main.ts
@@ -146,7 +146,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     recvClient = new SoraRecvClient(signalingUrl, channelId, secretKey);
 
     // forceStereoOutputを設定
-    const forceStereoOutput = document.querySelector("#force-stereo-output")!.checked;
+    const forceStereoOutput =
+      document.querySelector<HTMLInputElement>("#force-stereo-output")!.checked;
     recvClient.setForceStereoOutput(forceStereoOutput);
 
     // リモートストリーム受信時のコールバックを設定
@@ -163,7 +164,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     // 送信側を接続
     sendClient = new SoraSendClient(signalingUrl, channelId, secretKey);
 
-    const useStereo = document.querySelector("#use-stereo")!.checked;
+    const useStereo = document.querySelector<HTMLInputElement>("#use-stereo")!.checked;
 
     const stream = getFakeMedia({
       audio: {
@@ -206,7 +207,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const statsReport = await sendClient.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";
@@ -305,7 +306,7 @@ class SoraSendClient {
     // SDPデバッグ用
     this.connection.on("signaling", (event) => {
       if (event.type === "answer") {
-        console.log("Answer SDP (stereo check):", event.sdp?.includes("stereo=1"));
+        console.log("Answer SDP (stereo check):", (event as any).sdp?.includes("stereo=1"));
       }
     });
   }
@@ -357,6 +358,7 @@ class SoraRecvClient {
   private sora: SoraConnection;
   private connection: ConnectionSubscriber;
   private onStreamCallback: ((stream: MediaStream) => void) | null = null;
+  private remoteStream: MediaStream | null = null;
 
   constructor(signalingUrl: string, channelId: string, secretKey: string) {
     this.sora = Sora.connection(signalingUrl, this.debug);

--- a/e2e-tests/fake_stereo_audio_sendrecv/main.ts
+++ b/e2e-tests/fake_stereo_audio_sendrecv/main.ts
@@ -2,12 +2,7 @@ import { getFakeMedia } from "../src/fake";
 import { getChannelId, setSoraJsSdkVersion } from "../src/misc";
 
 import Sora from "sora-js-sdk";
-import type {
-  ConnectionPublisher,
-  SignalingEvent,
-  SignalingNotifyMessage,
-  SoraConnection,
-} from "sora-js-sdk";
+import type { ConnectionPublisher, SignalingNotifyMessage, SoraConnection } from "sora-js-sdk";
 
 // Soraオブジェクトをwindowに公開（テスト用）
 declare global {
@@ -145,12 +140,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
 
     // 接続1の設定を取得
-    const useStereo1 = document.querySelector("#use-stereo-1")!.checked;
-    const forceStereoOutput1 = document.querySelector("#force-stereo-output-1")!.checked;
+    const useStereo1 = document.querySelector<HTMLInputElement>("#use-stereo-1")!.checked;
+    const forceStereoOutput1 =
+      document.querySelector<HTMLInputElement>("#force-stereo-output-1")!.checked;
 
     // 接続2の設定を取得
-    const useStereo2 = document.querySelector("#use-stereo-2")!.checked;
-    const forceStereoOutput2 = document.querySelector("#force-stereo-output-2")!.checked;
+    const useStereo2 = document.querySelector<HTMLInputElement>("#use-stereo-2")!.checked;
+    const forceStereoOutput2 =
+      document.querySelector<HTMLInputElement>("#force-stereo-output-2")!.checked;
 
     // 接続1を作成
     soraClient1 = new SoraSendRecvClient(signalingUrl, channelId, secretKey, "1");
@@ -258,7 +255,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // 接続1の統計情報を取得
     const statsReport1 = await soraClient1.getStats();
-    const statsDiv1 = document.querySelector("#stats-report-1")!;
+    const statsDiv1 = document.querySelector<HTMLElement>("#stats-report-1")!;
     if (statsDiv1) {
       let statsHtml = "<h3>接続1の統計情報</h3>";
       const statsReportJson1: Array<Record<string, unknown>> = [];
@@ -283,7 +280,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // 接続2の統計情報を取得
     const statsReport2 = await soraClient2.getStats();
-    const statsDiv2 = document.querySelector("#stats-report-2")!;
+    const statsDiv2 = document.querySelector<HTMLElement>("#stats-report-2")!;
     if (statsDiv2) {
       let statsHtml = "<h3>接続2の統計情報</h3>";
       const statsReportJson2: Array<Record<string, unknown>> = [];
@@ -307,7 +304,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     // テスト用の音声解析データを保存
-    const analysisDiv = document.querySelector("#audio-analysis")!;
+    const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
     if (analysisDiv) {
       analysisDiv.dataset.analysis = JSON.stringify({
         connection1: {
@@ -380,6 +377,7 @@ class SoraSendRecvClient {
   private sora: SoraConnection;
   private connection: ConnectionPublisher;
   private onStreamCallback: ((stream: MediaStream) => void) | null = null;
+  private remoteStream: MediaStream | null = null;
   private connectionNumber: string;
 
   constructor(
@@ -400,11 +398,11 @@ class SoraSendRecvClient {
     this.connection.on("notify", this.onNotify.bind(this));
 
     // SDPデバッグ用
-    this.connection.on("signaling", (event: SignalingEvent) => {
+    this.connection.on("signaling", (event) => {
       if (event.type === "answer") {
         console.log(
           `Connection ${this.connectionNumber} Answer SDP (stereo check):`,
-          event.sdp?.includes("stereo=1"),
+          (event as any).sdp?.includes("stereo=1"),
         );
       }
     });

--- a/e2e-tests/h265/main.ts
+++ b/e2e-tests/h265/main.ts
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/messaging/main.ts
+++ b/e2e-tests/messaging/main.ts
@@ -23,9 +23,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
 
     client = new SoraClient(signalingUrl, channelId, secretKey);
-    const checkCompress = document.querySelector("#check-compress")!;
+    const checkCompress = document.querySelector<HTMLInputElement>("#check-compress")!;
     const compress = checkCompress.checked;
-    const checkHeader = document.querySelector("#check-header")!;
+    const checkHeader = document.querySelector<HTMLInputElement>("#check-header")!;
     const header = checkHeader.checked;
 
     await client.connect(compress, header);
@@ -42,7 +42,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/recvonly/main.ts
+++ b/e2e-tests/recvonly/main.ts
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/rpc/main.ts
+++ b/e2e-tests/rpc/main.ts
@@ -123,7 +123,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const statsReport = await recvonlyClient.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     if (statsDiv) {
       const statsReportJson: Array<Record<string, unknown>> = [];
       statsDiv.textContent = "";

--- a/e2e-tests/sendonly/main.ts
+++ b/e2e-tests/sendonly/main.ts
@@ -46,7 +46,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/sendonly_audio/main.ts
+++ b/e2e-tests/sendonly_audio/main.ts
@@ -15,11 +15,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
     // 音声コーデックの選択を取得
-    const audioCodecType = document.querySelector("#audio-codec-type")!;
+    const audioCodecType = document.querySelector<HTMLSelectElement>("#audio-codec-type")!;
     const selectedCodecType = audioCodecType.value === "OPUS" ? audioCodecType.value : undefined;
 
     // 音声ビットレートの選択を取得
-    const audioBitRateSelect = document.querySelector("#audio-bit-rate")!;
+    const audioBitRateSelect = document.querySelector<HTMLSelectElement>("#audio-bit-rate")!;
     const selectedBitRate = audioBitRateSelect.value
       ? Number.parseInt(audioBitRateSelect.value, 10)
       : undefined;
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/sendonly_reconnect/main.ts
+++ b/e2e-tests/sendonly_reconnect/main.ts
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/sendrecv/main.ts
+++ b/e2e-tests/sendrecv/main.ts
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/sendrecv_webkit/main.ts
+++ b/e2e-tests/sendrecv_webkit/main.ts
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await client.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/simulcast/main.ts
+++ b/e2e-tests/simulcast/main.ts
@@ -62,7 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await sendonly.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/simulcast_recvonly/main.ts
+++ b/e2e-tests/simulcast_recvonly/main.ts
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await recvonly.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/simulcast_sendonly/main.ts
+++ b/e2e-tests/simulcast_sendonly/main.ts
@@ -21,13 +21,14 @@ document.addEventListener("DOMContentLoaded", () => {
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
 
-    const videoCodecTypeElement = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeElement = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const videoCodecType = videoCodecTypeElement.value as VideoCodecType;
-    const rawVideoBitRate = document.querySelector("#video-bit-rate")!;
+    const rawVideoBitRate = document.querySelector<HTMLInputElement>("#video-bit-rate")!;
     const videoBitRate = Number.parseInt(rawVideoBitRate.value, 10);
 
     let simulcastEncodings: Record<string, unknown> | undefined;
-    const simulcastEncodingsElement = document.querySelector("#simulcast-encodings")!;
+    const simulcastEncodingsElement =
+      document.querySelector<HTMLInputElement>("#simulcast-encodings")!;
     if (simulcastEncodingsElement.value !== "") {
       console.log(`simulcastEncodingsElement.value=${simulcastEncodingsElement.value}`);
       try {
@@ -59,7 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await sendonly.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";
@@ -198,7 +199,7 @@ class SimulcastSendonlySoraClient {
 
   private updatePcState(): void {
     if (this.connection.pc) {
-      const pcStateElement = document.querySelector("#pc-state");
+      const pcStateElement = document.querySelector<HTMLElement>("#pc-state");
       if (pcStateElement) {
         const stateInfo = {
           connectionState: this.connection.pc.connectionState,

--- a/e2e-tests/simulcast_sendonly_webkit/main.ts
+++ b/e2e-tests/simulcast_sendonly_webkit/main.ts
@@ -21,13 +21,14 @@ document.addEventListener("DOMContentLoaded", () => {
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
 
-    const videoCodecTypeElement = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeElement = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const videoCodecType = videoCodecTypeElement.value as VideoCodecType;
-    const rawVideoBitRate = document.querySelector("#video-bit-rate")!;
+    const rawVideoBitRate = document.querySelector<HTMLInputElement>("#video-bit-rate")!;
     const videoBitRate = Number.parseInt(rawVideoBitRate.value, 10);
 
-    let simulcastEncodings: Array<Record<string, unknown>> | undefined;
-    const simulcastEncodingsElement = document.querySelector("#simulcast-encodings")!;
+    let simulcastEncodings: Record<string, unknown> | undefined;
+    const simulcastEncodingsElement =
+      document.querySelector<HTMLInputElement>("#simulcast-encodings")!;
     if (simulcastEncodingsElement.value !== "") {
       console.log(`simulcastEncodingsElement.value=${simulcastEncodingsElement.value}`);
       try {
@@ -59,7 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {
     const statsReport = await sendonly.getStats();
-    const statsDiv = document.querySelector("#stats-report")!;
+    const statsDiv = document.querySelector<HTMLElement>("#stats-report")!;
     const statsReportJsonDiv = document.querySelector("#stats-report-json");
     if (statsDiv && statsReportJsonDiv) {
       let statsHtml = "";

--- a/e2e-tests/tests/authz_simulcast_encodings.test.ts
+++ b/e2e-tests/tests/authz_simulcast_encodings.test.ts
@@ -55,7 +55,7 @@ test("authz simulcast encodings", async ({ page }) => {
   // connectionState が connected になるのを待つ
   await page.waitForFunction(
     () => {
-      const el = document.querySelector("#pc-state");
+      const el = document.querySelector("#pc-state") as HTMLElement;
       return el.dataset.connectionState === "connected";
     },
     { timeout: 15_000 },

--- a/e2e-tests/tests/h265.test.ts
+++ b/e2e-tests/tests/h265.test.ts
@@ -81,7 +81,7 @@ test("H265", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv1StatsReportJson: Array<Record<string, unknown>> = await sendrecv1.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -106,7 +106,7 @@ test("H265", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv2StatsReportJson: Array<Record<string, unknown>> = await sendrecv2.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/message_header.test.ts
+++ b/e2e-tests/tests/message_header.test.ts
@@ -93,7 +93,7 @@ test("messaging pages with header", async ({ browser }) => {
   await page1.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const page1StatsReportJson: Array<Record<string, unknown>> = await page1.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -131,7 +131,7 @@ test("messaging pages with header", async ({ browser }) => {
   await page2.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const page2StatsReportJson: Array<Record<string, unknown>> = await page2.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/messaging.test.ts
+++ b/e2e-tests/tests/messaging.test.ts
@@ -35,14 +35,14 @@ test("messaging pages", async ({ browser }) => {
 
   // Compress のTrue/Falseをランダムで設定する
   const selectedCompress1 = await page1.evaluate(() => {
-    const checkCompress = document.querySelector("#check-compress")!;
+    const checkCompress = document.querySelector<HTMLInputElement>("#check-compress")!;
     const getRandomBoolean = (): boolean => Math.random() >= 0.5;
     const randomCompress: boolean = getRandomBoolean();
     checkCompress.checked = randomCompress;
     return randomCompress;
   });
   const selectedCompress2 = await page2.evaluate(() => {
-    const checkCompress = document.querySelector("#check-compress")!;
+    const checkCompress = document.querySelector<HTMLInputElement>("#check-compress")!;
     const getRandomBoolean = (): boolean => Math.random() >= 0.5;
     const randomCompress: boolean = getRandomBoolean();
     checkCompress.checked = randomCompress;
@@ -110,7 +110,7 @@ test("messaging pages", async ({ browser }) => {
   await page1.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const page1StatsReportJson: Array<Record<string, unknown>> = await page1.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -148,7 +148,7 @@ test("messaging pages", async ({ browser }) => {
   await page2.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const page2StatsReportJson: Array<Record<string, unknown>> = await page2.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/sendonly_audio.test.ts
+++ b/e2e-tests/tests/sendonly_audio.test.ts
@@ -16,7 +16,7 @@ test("sendonly audio pages", async ({ browser }) => {
   // select 要素から直接オプションを取得してランダムに選択する
   // 音声コーデック
   const selectedAudioCodec = await sendonly.evaluate(() => {
-    const select = document.querySelector("#audio-codec-type")!;
+    const select = document.querySelector<HTMLSelectElement>("#audio-codec-type")!;
     const options = [...select.options];
     const randomOption = options[Math.floor(Math.random() * options.length)];
     select.value = randomOption.value;
@@ -24,7 +24,7 @@ test("sendonly audio pages", async ({ browser }) => {
   });
   // 音声ビットレート
   const selectedBitRate = await sendonly.evaluate(() => {
-    const select = document.querySelector("#audio-bit-rate")!;
+    const select = document.querySelector<HTMLSelectElement>("#audio-bit-rate")!;
     const options = [...select.options].filter((option) => option.value !== ""); // 未指定を除外
     const randomOption = options[Math.floor(Math.random() * options.length)];
     select.value = randomOption.value;
@@ -53,7 +53,7 @@ test("sendonly audio pages", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendonlyStatsReportJson: Array<Record<string, unknown>> = await sendonly.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/sendonly_recvonly.test.ts
+++ b/e2e-tests/tests/sendonly_recvonly.test.ts
@@ -55,7 +55,7 @@ test("sendonly/recvonly pages", async ({ browser }) => {
   await sendonly.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const sendonlyStatsReportJson: Array<Record<string, unknown>> = await sendonly.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -66,7 +66,7 @@ test("sendonly/recvonly pages", async ({ browser }) => {
   await recvonly.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const recvonlyStatsReportJson: Array<Record<string, unknown>> = await recvonly.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/sendrecv.test.ts
+++ b/e2e-tests/tests/sendrecv.test.ts
@@ -21,7 +21,7 @@ test("sendrecv x2", async ({ browser }) => {
 
   // sendrecv1 のビデオコーデックをランダムに選択
   await sendrecv1.evaluate(() => {
-    const videoCodecTypeSelect = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeSelect = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const options = [...videoCodecTypeSelect.options].filter((option) => option.value !== "");
     const randomIndex = Math.floor(Math.random() * options.length);
     videoCodecTypeSelect.value = options[randomIndex].value;
@@ -29,7 +29,7 @@ test("sendrecv x2", async ({ browser }) => {
 
   // sendrecv2 のビデオコーデックをランダムに選択
   await sendrecv2.evaluate(() => {
-    const videoCodecTypeSelect = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeSelect = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const options = [...videoCodecTypeSelect.options].filter((option) => option.value !== "");
     const randomIndex = Math.floor(Math.random() * options.length);
     videoCodecTypeSelect.value = options[randomIndex].value;
@@ -80,7 +80,7 @@ test("sendrecv x2", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv1StatsReportJson: Array<Record<string, unknown>> = await sendrecv1.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -124,7 +124,7 @@ test("sendrecv x2", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv2StatsReportJson: Array<Record<string, unknown>> = await sendrecv2.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/simulcast.test.ts
+++ b/e2e-tests/tests/simulcast.test.ts
@@ -45,7 +45,7 @@ test("simulcast sendonly/recvonly pages", async ({ page }) => {
   await page.waitForSelector("#stats-report");
   // データセットから統計情報を取得
   const sendonlyStatsReportJson: Array<Record<string, unknown>> = await page.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 

--- a/e2e-tests/tests/stereo_audio.test.ts
+++ b/e2e-tests/tests/stereo_audio.test.ts
@@ -74,13 +74,13 @@ test.describe("Stereo Audio Tests", () => {
 
     // 送信側の統計情報を取得
     const sendStatsReportJson: Array<Record<string, unknown>> = await page.evaluate(() => {
-      const statsReportDiv = document.querySelector("#stats-report")!;
+      const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
       return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
     });
 
     // 受信側の統計情報を取得
     const recvStatsReportJson: Array<Record<string, unknown>> = await page.evaluate(() => {
-      const recvStatsDiv = document.querySelector("[data-recv-stats-report-json]")!;
+      const recvStatsDiv = document.querySelector<HTMLElement>("[data-recv-stats-report-json]")!;
       return recvStatsDiv ? JSON.parse(recvStatsDiv.dataset.recvStatsReportJson ?? "[]") : [];
     });
 
@@ -102,7 +102,7 @@ test.describe("Stereo Audio Tests", () => {
 
     // 音声分析結果を取得
     const analysisData = await page.evaluate(() => {
-      const analysisDiv = document.querySelector("#audio-analysis")!;
+      const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
       return analysisDiv ? JSON.parse(analysisDiv.dataset.analysis ?? "{}") : {};
     });
 
@@ -170,7 +170,7 @@ test.describe("Stereo Audio Tests", () => {
 
     // 送信側の統計情報を取得
     const sendStatsReportJson: Array<Record<string, unknown>> = await page.evaluate(() => {
-      const statsReportDiv = document.querySelector("#stats-report")!;
+      const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
       return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
     });
 
@@ -184,7 +184,7 @@ test.describe("Stereo Audio Tests", () => {
 
     // 音声分析結果を取得
     const analysisData = await page.evaluate(() => {
-      const analysisDiv = document.querySelector("#audio-analysis")!;
+      const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
       return analysisDiv ? JSON.parse(analysisDiv.dataset.analysis ?? "{}") : {};
     });
 

--- a/e2e-tests/tests/stereo_audio_sendrecv.test.ts
+++ b/e2e-tests/tests/stereo_audio_sendrecv.test.ts
@@ -72,13 +72,13 @@ test.describe("Stereo Audio SendRecv Tests", () => {
 
     // 接続1の統計情報を取得
     const stats1Json: Array<Record<string, unknown>> = await page.evaluate(() => {
-      const statsDiv = document.querySelector("#stats-report-1")!;
+      const statsDiv = document.querySelector<HTMLElement>("#stats-report-1")!;
       return statsDiv ? JSON.parse(statsDiv.dataset.statsReportJson ?? "[]") : [];
     });
 
     // 接続2の統計情報を取得
     const stats2Json: Array<Record<string, unknown>> = await page.evaluate(() => {
-      const statsDiv = document.querySelector("#stats-report-2")!;
+      const statsDiv = document.querySelector<HTMLElement>("#stats-report-2")!;
       return statsDiv ? JSON.parse(statsDiv.dataset.statsReportJson ?? "[]") : [];
     });
 
@@ -114,7 +114,7 @@ test.describe("Stereo Audio SendRecv Tests", () => {
 
     // 音声分析結果を取得
     const analysisData = await page.evaluate(() => {
-      const analysisDiv = document.querySelector("#audio-analysis")!;
+      const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
       return analysisDiv ? JSON.parse(analysisDiv.dataset.analysis ?? "{}") : {};
     });
 
@@ -196,7 +196,7 @@ test.describe("Stereo Audio SendRecv Tests", () => {
 
     // 音声分析結果を取得
     const analysisData = await page.evaluate(() => {
-      const analysisDiv = document.querySelector("#audio-analysis")!;
+      const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
       return analysisDiv ? JSON.parse(analysisDiv.dataset.analysis ?? "{}") : {};
     });
 
@@ -283,7 +283,7 @@ test.describe("Stereo Audio SendRecv Tests", () => {
 
     // 音声分析結果を取得
     const analysisData = await page.evaluate(() => {
-      const analysisDiv = document.querySelector("#audio-analysis")!;
+      const analysisDiv = document.querySelector<HTMLElement>("#audio-analysis")!;
       return analysisDiv ? JSON.parse(analysisDiv.dataset.analysis ?? "{}") : {};
     });
 

--- a/e2e-tests/tests/webkit.test.ts
+++ b/e2e-tests/tests/webkit.test.ts
@@ -26,7 +26,7 @@ test("WebKit", async ({ browser }) => {
 
   // sendrecv1 のビデオコーデックをランダムに選択
   await sendrecv1.evaluate(() => {
-    const videoCodecTypeSelect = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeSelect = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const options = [...videoCodecTypeSelect.options].filter((option) => option.value !== "");
     const randomIndex = Math.floor(Math.random() * options.length);
     videoCodecTypeSelect.value = options[randomIndex].value;
@@ -34,7 +34,7 @@ test("WebKit", async ({ browser }) => {
 
   // sendrecv2 のビデオコーデックをランダムに選択
   await sendrecv2.evaluate(() => {
-    const videoCodecTypeSelect = document.querySelector("#video-codec-type")!;
+    const videoCodecTypeSelect = document.querySelector<HTMLSelectElement>("#video-codec-type")!;
     const options = [...videoCodecTypeSelect.options].filter((option) => option.value !== "");
     const randomIndex = Math.floor(Math.random() * options.length);
     videoCodecTypeSelect.value = options[randomIndex].value;
@@ -85,7 +85,7 @@ test("WebKit", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv1StatsReportJson: Array<Record<string, unknown>> = await sendrecv1.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 
@@ -129,7 +129,7 @@ test("WebKit", async ({ browser }) => {
 
   // データセットから統計情報を取得
   const sendrecv2StatsReportJson: Array<Record<string, unknown>> = await sendrecv2.evaluate(() => {
-    const statsReportDiv = document.querySelector("#stats-report")!;
+    const statsReportDiv = document.querySelector<HTMLElement>("#stats-report")!;
     return statsReportDiv ? JSON.parse(statsReportDiv.dataset.statsReportJson ?? "[]") : [];
   });
 


### PR DESCRIPTION
## 概要

TypeScript 7.0 (Go 実装) への移行準備として、@typescript/native-preview (tsgo) による型検証ジョブを CI に追加する。

## 変更内容

- `.github/workflows/ci.yaml` に `typescript-native-preview` ジョブを追加
  - JS 版 `typescript` を CI 環境から除外し `@typescript/native-preview` をインストール
  - `tsgo --emitDeclarationOnly -p tsconfig.json` で SDK 本体の宣言ファイルを生成
  - `tsgo --noEmit -p e2e-tests/tsconfig.json` で e2e-tests の型検証を実行
- `slack_notify` の `needs` に `typescript-native-preview` を追加
- e2e-tests の既存型エラー (querySelector 戻り値 Element に対する DOM プロパティアクセス) を 28 ファイルにわたって修正
- `CHANGES.md` の `develop` セクションに追記

## 完了条件

- [x] `package.json` / `pnpm-lock.yaml` にリポジトリへコミットされる変更がない
- [x] 既存 `ci` ジョブは退行なくそのまま動作する
- [x] e2e-tests の型エラーが解消され `tsgo` で両方の検証が成功する
- [x] `tsgo` 検証失敗時に CI job が fail する

## 関連 issue

- issues/0038-ci-add-typescript-native-preview-verification.md