### PR TITLE
0005 disconnectWebSocket が null を返すと disconnect callback が発火しない を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
   - @voluntas
 - [FIX] onDataChannel で同名 label の DataChannel を上書きする際に旧 DC のハンドラを解除し close するようにする
   - @voluntas
+- [FIX] disconnect() で WebSocket が OPEN 以外の状態のときに disconnect callback が発火しなかったのを修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0005-bug-fix-disconnect-websocket-null-callback-not-fired.md
+++ b/issues/closed/0005-bug-fix-disconnect-websocket-null-callback-not-fired.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-08
+- Completed: 2026-06-09
 - Model: Opus 4.7
 - Branch: feature/fix-disconnect-websocket-null-callback
 
@@ -92,3 +93,7 @@ High。経路 B は接続済み (または connect 試行中に `this.ws` 代入
 - 870 経路 (未接続 / connect 失敗直後) で callback を発火させる要件
 - issue 0031 (`signalingSwitched === true` 経路の event 上書き)
 - 0002 マージ後の sequential 2 回目 `disconnect()` (870 経路) の callback 再発火 (870 は引き続き null で不発が正しい)
+
+## 解決方法
+
+`src/base.ts` の `disconnectWebSocket` の `readyState !== 1` 経路 (経路 B、0002 マージ後の 905-911 行) で `resolve(null)` を `resolve({ code: 1000, reason: "NO-ERROR" })` に変更した。`!this.ws` の経路 (現状 874-877 行、null 返却で callback 不発が意図的) と `signalingSwitched === true` の早期 return (866-872 行、event は disconnectDataChannel で別途設定) には触れていない。これにより `signalingSwitched === false` かつ `this.ws` が OPEN 以外の状態で `disconnect()` を呼んだ際、呼び出し側 (`disconnect()` 1097-1104 行) の `if (reason !== null)` を通って `callbacks.disconnect` が `event.title === "DISCONNECT"` で 1 回発火する。コメントは「実 CloseEvent を待たず synthetic 値で即 resolve する」「callbacks.disconnect を発火させるため null ではなく normal 切断扱いの値を返す」の 2 行に整理した。E2E は本文どおり best-effort で、経路 B を決定論的に踏ませる手段がなく false green リスクが高いため本 PR では追加しない (回帰の主担保はコードレビュー)。既存 `pnpm test` (2 files, 72 tests) が通過することを確認した。CHANGES.md `## develop` に FIX エントリを追記した。

--- a/src/base.ts
+++ b/src/base.ts
@@ -903,10 +903,11 @@ export default class ConnectionBase {
           resolve({ code: 1006, reason: "" });
         }, this.disconnectWaitTimeout);
       } else {
-        // ws の state が open ではない場合は後処理をして終わる
+        // readyState が OPEN ではない場合は実 CloseEvent を待たず synthetic 値で即 resolve する
+        // callbacks.disconnect を発火させるため null ではなく normal 切断扱いの値を返す
         this.ws.close();
         this.ws = null;
-        resolve(null);
+        resolve({ code: 1000, reason: "NO-ERROR" });
       }
     });
   }


### PR DESCRIPTION
## 概要

`disconnect()` の `signalingSwitched === false` 経路で、`disconnectWebSocket` が `readyState !== 1` (CLOSING / CLOSED 等) のときに `null` を返し、呼び出し側の `if (reason !== null)` を素通りして `callbacks.disconnect` が発火しなかったのを修正する。

## 変更内容

- `src/base.ts` の `disconnectWebSocket` 経路 B (`readyState !== 1` の else 節) で `resolve(null)` を `resolve({ code: 1000, reason: "NO-ERROR" })` に変更
- `!this.ws` の経路 (null 返却で callback 不発が意図的) と `signalingSwitched === true` の早期 return には触れていない
- 該当箇所のコメントを「実 CloseEvent を待たず synthetic 値で即 resolve する」「`callbacks.disconnect` を発火させるため null ではなく normal 切断扱いの値を返す」の 2 行に整理
- issue を `issues/closed/` に移動し `Completed: 2026-06-09` と `## 解決方法` を追記
- `CHANGES.md` `## develop` に FIX エントリを追記

## 完了条件

- [x] `disconnectWebSocket` の経路 B が OPEN 以外の ws に対して `{ code: 1000, reason: "NO-ERROR" }` を返す (`!this.ws` 経路は `null` のまま)
- [x] `signalingSwitched === false` かつ経路 B で `disconnect()` した場合、`callbacks.disconnect` が 1 回発火し `event.title === "DISCONNECT"` であること (コード読みで担保)
- [x] `!this.ws` 経路では引き続き `callbacks.disconnect` が発火しないこと
- [x] ローカルで `pnpm test` が通る (2 files, 72 tests)
- [x] `CHANGES.md` `## develop` に FIX エントリを追記

## テストと回帰検出について

- 単体テスト追加: なし (`tests/` 配下は純粋関数のみ、`WebSocket` をモック禁止のため `disconnectWebSocket` の経路 B を直接駆動するテストは書けない)
- E2E 追加: なし (経路 B = `this.ws` 存在かつ `readyState !== 1` かつ `signalingSwitched === false` を決定論的に踏ませる手段がなく false green リスクが高い)
- **本修正の正しさはコードレビューで担保する**

## 関連 issue

- issues/closed/0005-bug-fix-disconnect-websocket-null-callback-not-fired.md
- マージ順: 0002 (済) → **0005 (本 PR)** → 0030