### PR TITLE
0006 monitorPeerConnectionState の iceConnectionState: disconnected 10 秒タイマーが現行ブラウザで動作しないのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
   - @voluntas
 - [FIX] disconnect() で WebSocket が OPEN 以外の状態のときに disconnect callback が発火しなかったのを修正する
   - @voluntas
+- [FIX] iceConnectionState が disconnected で 10 秒経過した際の検知が現行ブラウザで動作していなかったのを修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0006-bug-fix-monitor-ice-disconnected-timer-dead-code.md
+++ b/issues/closed/0006-bug-fix-monitor-ice-disconnected-timer-dead-code.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-21
+- Completed: 2026-06-09
 - Polished: 2026-06-08
 - Model: Opus 4.7
 - Branch: feature/fix-monitor-ice-disconnected-timer
@@ -86,3 +87,32 @@ this.pc.oniceconnectionstatechange = (_): void => {
 **検証の限界:** デッドコード修正の核心は CI 未カバー (`tests/` / `e2e-tests/` に ICE 状態遷移テストなし、モック禁止)。手動検証手順 (OS / ブラウザ、ネットワーク down 手順、期待 timeline `ICE-CONNECTION-STATE-DISCONNECTED-TIMEOUT`) は PR 説明に記載する (新規 README は作らない)。10 秒タイマー自体は既にコード上 `10_000` 実装済みで本 fix はガード削除のみ (CHANGES.md の旧 1000ms 記載との差は PR で触れる)。
 
 **マージ順:** `0006 → 0011 → 0030` (0030 は推奨同周期)。リポジトリ全体の正本チェーンは issue 0004 を参照。
+
+## 解決方法
+
+`src/base.ts` を以下のとおり修正した。
+
+### 1. `monitorPeerConnectionState` の `oniceconnectionstatechange` ガード削除
+
+- `connectionState === undefined` ガードを削除し、デッドコード化していた以下のロジックを現行ブラウザでも動作するようにした。
+  - `iceConnectionState === "disconnected"` 滞留 10 秒タイマーによる `abendPeerConnectionState("ICE-CONNECTION-STATE-DISCONNECTED-TIMEOUT")`
+  - `iceConnectionState === "failed"` 即時の `abendPeerConnectionState("ICE-CONNECTION-STATE-FAILED")` (副作用 1 として再有効化)
+- `if (!this.pc) return;` の null ガードのみ残し、ハンドラ剥がしと pc null 化のレース時に late dispatch されたイベントでクラッシュしないようにした。
+- 削除した stale コメント (`// connectionState が undefined の場合は iceConnectionState を見て判定する`) を削除した。
+
+### 2. `clearMonitorIceConnectionStateChange` の API ペア整合
+
+- `clearInterval` を `clearTimeout` に修正し、`setTimeout` でセットしたタイマーを `clearTimeout` で止める形に統一した (clarity 改善)。
+- ブラウザでは `setTimeout` / `setInterval` の timer ID 名前空間が共有されるため機能上の挙動は変わらない。
+- 併せて JSDoc を「`oniceconnectionstatechange` でセットした `iceConnectionState === "disconnected"` 滞留検知の setTimeout タイマーを止めるメソッド」と詳細化した。
+
+### 変更ファイル
+
+- `src/base.ts`
+- `CHANGES.md` (`## develop` に `[FIX]` エントリを追記)
+
+### テスト
+
+- 既存の `tests/utils.test.ts` / `tests/version-check.test.ts` には本変更の影響範囲のテストが無く、`AGENTS.md` の「モック・スタブ禁止」によりブラウザ API である `RTCPeerConnection.iceConnectionState` の状態遷移を作為的に再現するテストを単体テスト / PBT として書くことはできない。
+- ローカルで `pnpm test` / `pnpm typecheck` / `pnpm lint` / `pnpm fmt` を実行し全て通過することを確認した。
+- 手動検証手順は PR 本文に記載した。

--- a/src/base.ts
+++ b/src/base.ts
@@ -1677,27 +1677,27 @@ export default class ConnectionBase {
       return;
     }
     this.pc.oniceconnectionstatechange = (_): void => {
-      // connectionState が undefined の場合は iceConnectionState を見て判定する
-      if (this.pc && this.pc.connectionState === undefined) {
-        this.writePeerConnectionTimelineLog("oniceconnectionstatechange", {
-          connectionState: this.pc.connectionState,
-          iceConnectionState: this.pc.iceConnectionState,
-          iceGatheringState: this.pc.iceGatheringState,
-        });
-        this.trace("ONICECONNECTIONSTATECHANGE ICECONNECTIONSTATE", this.pc.iceConnectionState);
-        clearTimeout(this.monitorIceConnectionStateChangeTimerId);
-        // iceConnectionState "failed" で切断する
-        if (this.pc.iceConnectionState === "failed") {
-          this.abendPeerConnectionState("ICE-CONNECTION-STATE-FAILED");
-        }
-        // iceConnectionState "disconnected" になってから 10000ms の間変化がない場合切断する
-        else if (this.pc.iceConnectionState === "disconnected") {
-          this.monitorIceConnectionStateChangeTimerId = setTimeout(() => {
-            if (this.pc?.iceConnectionState === "disconnected") {
-              this.abendPeerConnectionState("ICE-CONNECTION-STATE-DISCONNECTED-TIMEOUT");
-            }
-          }, 10_000);
-        }
+      if (!this.pc) {
+        return;
+      }
+      this.writePeerConnectionTimelineLog("oniceconnectionstatechange", {
+        connectionState: this.pc.connectionState,
+        iceConnectionState: this.pc.iceConnectionState,
+        iceGatheringState: this.pc.iceGatheringState,
+      });
+      this.trace("ONICECONNECTIONSTATECHANGE ICECONNECTIONSTATE", this.pc.iceConnectionState);
+      clearTimeout(this.monitorIceConnectionStateChangeTimerId);
+      // iceConnectionState "failed" で切断する
+      if (this.pc.iceConnectionState === "failed") {
+        this.abendPeerConnectionState("ICE-CONNECTION-STATE-FAILED");
+      }
+      // iceConnectionState "disconnected" になってから 10000ms の間変化がない場合切断する
+      else if (this.pc.iceConnectionState === "disconnected") {
+        this.monitorIceConnectionStateChangeTimerId = setTimeout(() => {
+          if (this.pc?.iceConnectionState === "disconnected") {
+            this.abendPeerConnectionState("ICE-CONNECTION-STATE-DISCONNECTED-TIMEOUT");
+          }
+        }, 10_000);
       }
     };
     this.pc.onconnectionstatechange = (_): void => {
@@ -1763,10 +1763,11 @@ export default class ConnectionBase {
   }
 
   /**
-   * monitorPeerConnectionState でセットしたタイマーを止めるメソッド
+   * monitorPeerConnectionState の oniceconnectionstatechange でセットした
+   * iceConnectionState === "disconnected" 滞留検知の setTimeout タイマーを止めるメソッド
    */
   protected clearMonitorIceConnectionStateChange(): void {
-    clearInterval(this.monitorIceConnectionStateChangeTimerId);
+    clearTimeout(this.monitorIceConnectionStateChangeTimerId);
   }
 
   /**


### PR DESCRIPTION
## 概要

`monitorPeerConnectionState` (`src/base.ts`) の `oniceconnectionstatechange` で `iceConnectionState === "disconnected"` の 10 秒タイマーが `connectionState === undefined` ガード内でしか起動していなかった。`README.md` 記載の対応ブラウザ (Chrome / Edge 80+、Firefox 113+、Safari 16.4+) はすべて `RTCPeerConnection.connectionState` を実装済みでこのガードは常に false となっており、`disconnected` 滞留検知と `iceConnectionState === "failed"` 検知の双方がデッドコードだった。

ガードを外して現行ブラウザでも `disconnected` 滞留検知を動作させる。`disconnected` から `failed` への遷移は WebRTC 仕様上実装依存で、ブラウザによっては `disconnected` のまま `failed` に遷移しないため、Wi-Fi / 5G 切り替え等の接続失効を検知できない問題を解消する。

## 変更内容

### `src/base.ts`

- `monitorPeerConnectionState` の `oniceconnectionstatechange` の `connectionState === undefined` ガードを削除し、`if (!this.pc) return;` の null ガードのみ残した。
- stale な「`// connectionState が undefined の場合は iceConnectionState を見て判定する`」コメントを削除した。
- `clearMonitorIceConnectionStateChange` の `clearInterval` を `clearTimeout` に修正し、`setTimeout` でセットしたタイマーを `clearTimeout` で止める形に統一した (clarity 改善)。ブラウザでは `setTimeout` / `setInterval` の timer ID 名前空間が共有されるため機能上の挙動は変わらない。
- `clearMonitorIceConnectionStateChange` の JSDoc を「`oniceconnectionstatechange` でセットした `iceConnectionState === "disconnected"` 滞留検知の setTimeout タイマーを止めるメソッド」と詳細化した。

### 副作用

issue 0006 の設計方針節 (採用案: ガード全体削除) のとおり、本修正には以下の副作用がある。

- 副作用 1: `iceConnectionState === "failed"` での `abendPeerConnectionState("ICE-CONNECTION-STATE-FAILED")` も同時に再有効化される (現行ではデッドコード)。
- 副作用 2: `oniceconnectionstatechange` の timeline / trace ログが現行ブラウザで増加する。

### `CHANGES.md`

`## develop` に以下を追記した。

- ` - [FIX] iceConnectionState が disconnected で 10 秒経過した際の検知が現行ブラウザで動作していなかったのを修正する`

## 完了条件

- [x] `connectionState === undefined` ガードを削除し、`disconnected` 10 秒タイマーが現行ブラウザで動作する
- [x] `clearMonitorIceConnectionStateChange` が `clearTimeout` を使う
- [x] stale コメントを削除する
- [x] ローカルで `pnpm test` が通る (72 件全件パス)
- [x] ローカルで `pnpm typecheck` / `pnpm lint` / `pnpm fmt` が通る
- [x] `CHANGES.md` の `## develop` に `[FIX]` エントリを追記する
- [ ] `pnpm e2e-test` (CI で実行)

## 検証の限界と手動検証手順

`tests/` / `e2e-tests/` には `iceConnectionState` の状態遷移を再現するテストが無く、`AGENTS.md` の「モック・スタブ禁止」によりブラウザ API である `RTCPeerConnection.iceConnectionState` の状態遷移を作為的に再現する単体テスト / PBT は書けない。既存 e2e の `reconnect.test.ts` も `apiDisconnect` 経由で `shutdown` 経路に入るため、本修正の `oniceconnectionstatechange` 内の `disconnected` / `failed` 分岐は通らない。

CI 緑 ≠ 本修正動作確認 であることに注意。マージ前に以下の手動検証手順で `disconnected` 滞留検知の動作を確認すること。

### 手動検証手順

1. **`disconnected` 10 秒タイマー発火経路**
   - 例: macOS の Google Chrome stable で `e2e-tests/sendonly` 系ページに接続する。
   - `networksetup -setairportpower en0 off` 等で Wi-Fi を切断する。
   - 10 秒経過後に `callbacks.disconnect` が `abend` で発火し、`timeline` ログに `disconnect-abend` の title `ICE-CONNECTION-STATE-DISCONNECTED-TIMEOUT` が記録されることを確認する。
2. **`disconnected` → `connected` 復帰経路**
   - 1 と同様に接続し、10 秒以内に Wi-Fi を戻す。
   - `callbacks.disconnect` が発火しないこと、`monitorIceConnectionStateChangeTimerId` の `clearTimeout` が効いていることを確認する。
3. **タイマー clear の回帰確認**
   - 接続後に Wi-Fi を切断し、10 秒未満で `disconnect()` を明示呼び出しする。
   - `callbacks.disconnect` が二重発火しないこと、孤児タイマーが残らないことを確認する。
4. **`iceConnectionState === "failed"` 経路 (副作用 1)**
   - 再現が難しいため best effort。再現できない場合でも mergeable とする。

## マージ順

`0006 → 0011 → 0030` (0030 は推奨同周期)。

- 0006 と 0011 の関係: 0006 適用後にタイマーが実際に動き始める。`signalingTerminate` → `initializeConnection` は `clearMonitorIceConnectionStateChange` を呼ばないため、0011 の `initializeConnection` への clear 追加で初めて孤児タイマー経路が完全に塞がる。0006 単独マージでも実害は低いが、0011 をセットでマージするのが望ましい。
- 0006 と 0030 の関係: 副作用 1 で ICE failed が `oniceconnectionstatechange` と `onconnectionstatechange` の両方から検知されうるが、`abendPeerConnectionState` は同期メソッドで先に走った片方が同期的に相手のハンドラを剥がし、後続イベントは発火しない。よって 0006 単独マージしても二重発火しない。ただし 0030 が `abendPeerConnectionState` を非同期化すると二重発火が再発しうるため、0030 と同周期リリースを推奨する。

## スコープ外 (残余リスク)

- `waitChangeConnectionStateConnected` (`src/base.ts:1581-1597`) も本 issue と同じ根拠 (`connectionState === undefined` ガードが対応ブラウザでデッドコード) を満たすが、本 issue のスコープは `monitorPeerConnectionState` に限定する。別 issue で対応する。
- `connectionState === "disconnected"` 滞留は未監視のまま。ice 側復旧で大半をカバーする前提で、現状仕様。

## 関連 issue

- `issues/closed/0006-bug-fix-monitor-ice-disconnected-timer-dead-code.md`