### PR TITLE
0021 ConnectError の constructor を (message, code?, reason?) に拡張し後付け代入を廃止する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@
 - [UPDATE] oxc の lint / fmt 設定を vite.config.ts に統合する
   - `.oxlintrc.jsonc` と `.oxfmtrc.jsonc` を削除する
   - @voluntas
+- [UPDATE] 内部 ConnectError の constructor で code と reason を引数として受け取れるようにし base.ts の後付け代入を廃止する
+  - @voluntas
 - [FIX] Node 24 で `playwright install` がハングする問題を修正するため Playwright を 1.60.0 に更新する
   - @voluntas
 - [FIX] macOS の Google Chrome stable インストールが 302 リダイレクトを追従できず失敗するため playwright-core にパッチを当てて `curl` に `-L` を追加する

--- a/issues/closed/0021-refactor-connect-error-constructor.md
+++ b/issues/closed/0021-refactor-connect-error-constructor.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-21
+- Completed: 2026-06-10
 - Polished: 2026-06-10
 - Model: Opus 4.7
 - Branch: feature/refactor-connect-error-constructor
@@ -188,3 +189,43 @@ test("ConnectError は code を undefined で reason のみ指定して生成で
 ```
 
 0001 は既に close 済み (正本チェーン上の位置を保持する目的で記載)。加えて `0021 → 0012` (`removeXxxTrack` の `ConnectError` reject) も 0021 を前提とする。`ConnectError` の新 constructor を直接利用するのは 0007 / 0008 / 0012 の 3 件。0009 / 0034 は `ConnectError` を新規には投げないが、正本チェーン上の順序を維持するため記載する。
+
+## 解決方法
+
+### `src/utils.ts`
+
+`ConnectError` の constructor を `(message?: string)` から `(message: string, code?: number, reason?: string)` に拡張した。constructor 内で `this.code = code` / `this.reason = reason` の初期化を追加し、`this.name = "ConnectError"` の設定は既存維持とした。`Object.setPrototypeOf` は追加していない (`tsconfig.json` の `target: "ES2022"` 下でネイティブ class 継承により `instanceof` が正しく動作するため、`src/errors.ts` の既存クラスとも方針を統一)。
+
+加えて、`code` / `reason` の用途が誤読されないよう、`ConnectError` クラスに JSDoc を追加した。`code` は WebSocket Close Code (IANA) 専用、`reason` は CloseEvent の reason 文字列または SDK 内部のエラー分類コード (大文字スネークケース、例: `WS_SEND_FAILED`) のいずれかが入る、と明文化している。
+
+### `src/base.ts`
+
+後付け代入 3 箇所 (`getSignalingWebSocket` の string 経路 onclose、`signaling` の onclose、`monitorSignalingWebSocketEvent` の onclose) で `error.code = event.code;` / `error.reason = event.reason;` の 2 行を削除し、`new ConnectError(...)` の constructor 引数 (`event.code`, `event.reason`) として渡す形に書き換えた。`writeWebSocketTimelineLog` / `signalingTerminate` / `reject` の呼び出しは現状維持。
+
+`new ConnectError(message)` のみの 4 箇所 (`:1138, :1248, :1251, :1625`) は変更しない。いずれも第 1 引数で `message` を必ず渡しているため、`message` 必須化により破壊されない。
+
+### `tests/utils.test.ts`
+
+末尾に `ConnectError` のテストを 4 件追加した。
+
+- `new ConnectError(message)` で code / reason が undefined のまま生成され、name が `"ConnectError"` で `ConnectError` 型として識別できることを確認する
+- `new ConnectError(message, code, reason)` で 3 引数すべてが initializer 引数で初期化されることを確認する
+- `new ConnectError(message, code)` で reason が undefined のまま生成されることを確認する
+- `new ConnectError(message, undefined, reason)` で reason のみが設定されることを確認する (後続 issue が利用するパターン)
+
+既存の `import { createSignalingMessage } from "../src/utils";` を `import { ConnectError, createSignalingMessage } from "../src/utils";` に書き換えた (vite-plus の `import/no-duplicates` ルール対策)。
+
+### `CHANGES.md`
+
+`## develop` の `### misc` セクション内、既存 `[UPDATE]` 群末尾に以下のエントリを追記した。
+
+```
+- [UPDATE] 内部 ConnectError の constructor で code と reason を引数として受け取れるようにし base.ts の後付け代入を廃止する
+  - @voluntas
+```
+
+### 検証
+
+- ローカルで `pnpm test` が通る (本 issue で追加した 4 件のテストを含む計 76 件)
+- ローカルで `pnpm typecheck` が通る
+- ローカルで `pnpm lint` が通る

--- a/src/base.ts
+++ b/src/base.ts
@@ -1150,9 +1150,9 @@ export default class ConnectionBase {
         ws.onclose = (event): void => {
           const error = new ConnectError(
             `Signaling failed. CloseEventCode:${event.code} CloseEventReason:'${event.reason}'`,
+            event.code,
+            event.reason,
           );
-          error.code = event.code;
-          error.reason = event.reason;
           this.writeWebSocketTimelineLog("onclose", error);
           reject(error);
         };
@@ -1275,9 +1275,9 @@ export default class ConnectionBase {
       ws.onclose = (event): void => {
         const error = new ConnectError(
           `Signaling failed. CloseEventCode:${event.code} CloseEventReason:'${event.reason}'`,
+          event.code,
+          event.reason,
         );
-        error.code = event.code;
-        error.reason = event.reason;
         this.writeWebSocketTimelineLog("onclose", error);
         this.signalingTerminate();
         reject(error);
@@ -1614,9 +1614,9 @@ export default class ConnectionBase {
         this.ws.onclose = (event): void => {
           const error = new ConnectError(
             `Signaling failed. CloseEventCode:${event.code} CloseEventReason:'${event.reason}'`,
+            event.code,
+            event.reason,
           );
-          error.code = event.code;
-          error.reason = event.reason;
           this.writeWebSocketTimelineLog("onclose", error);
           this.signalingTerminate();
           reject(error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -411,13 +411,23 @@ export function trace(clientId: string | null, title: string, value: unknown): v
   }
 }
 
+/**
+ * Sora SDK の接続/切断系の失敗を表すエラー
+ *
+ * - code: WebSocket CloseEvent の code (IANA WebSocket Close Code) のみ格納する。
+ *   それ以外の用途では使用しない。
+ * - reason: WebSocket CloseEvent の reason 文字列、または SDK 内部のエラー分類コード
+ *   (大文字スネークケース、例: WS_SEND_FAILED) のいずれかが入る。
+ */
 export class ConnectError extends Error {
   code?: number;
   reason?: string;
 
-  constructor(message?: string) {
+  constructor(message: string, code?: number, reason?: string) {
     super(message);
     this.name = "ConnectError";
+    this.code = code;
+    this.reason = reason;
   }
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,7 +1,7 @@
 // XXX: assert を使うと型がエラーがうるさいため expect を使ってる
 
 import type { AudioCodecType, DataChannelDirection, VideoCodecType } from "../src/types";
-import { createSignalingMessage } from "../src/utils";
+import { ConnectError, createSignalingMessage } from "../src/utils";
 
 const channelId = "7N3fsMHob";
 const metadata = "PG9A6RXgYqiqWKOVO";
@@ -838,4 +838,41 @@ test("createSignalingMessage audioStreamingLanguageCode: ja-JP", () => {
   expect(
     createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
   ).toStrictEqual(expectedMessage);
+});
+
+/**
+ * ConnectError のテスト
+ */
+
+// message のみ渡した場合は code / reason が undefined のまま生成され
+// name が "ConnectError" となり ConnectError 型として識別できる
+test("new ConnectError(message) は code / reason を undefined にして生成する", () => {
+  const e = new ConnectError("msg");
+  expect(e.message).toBe("msg");
+  expect(e.name).toBe("ConnectError");
+  expect(e.code).toBeUndefined();
+  expect(e.reason).toBeUndefined();
+  expect(e).toBeInstanceOf(ConnectError);
+});
+
+// 3 引数すべて渡した場合は code / reason が constructor 引数で初期化される
+test("new ConnectError(message, code, reason) は 3 引数すべてを初期化する", () => {
+  const e = new ConnectError("close", 1006, "abnormal");
+  expect(e.message).toBe("close");
+  expect(e.code).toBe(1006);
+  expect(e.reason).toBe("abnormal");
+});
+
+// code だけ指定して reason を省略した場合は reason が undefined のまま生成される
+test("new ConnectError(message, code) は reason を undefined のまま生成する", () => {
+  const e = new ConnectError("close", 1006);
+  expect(e.code).toBe(1006);
+  expect(e.reason).toBeUndefined();
+});
+
+// code を undefined にして SDK 内部のエラー分類コードを reason のみで指定するパターン
+test("new ConnectError(message, undefined, reason) は reason のみを設定する", () => {
+  const e = new ConnectError("ws send failed", undefined, "WS_SEND_FAILED");
+  expect(e.code).toBeUndefined();
+  expect(e.reason).toBe("WS_SEND_FAILED");
 });


### PR DESCRIPTION
## 概要

`ConnectError` (src/utils.ts) の constructor を 1 引数 `(message?: string)` から 3 引数 `(message: string, code?: number, reason?: string)` に拡張し、`src/base.ts` の 3 箇所で残っていた `error.code = event.code;` / `error.reason = event.reason;` の後付け代入を廃止する。後続 issue 0007 / 0008 / 0012 が `new ConnectError("...", undefined, "REASON_CODE")` 形式の constructor 呼び出しを前提に設計されているため、その先行整備として必要。

## 変更内容

- `src/utils.ts` の `ConnectError` constructor を `(message: string, code?: number, reason?: string)` に拡張する
- `src/utils.ts` の `ConnectError` に JSDoc を追加し、`code` は WebSocket Close Code (IANA) 専用、`reason` は CloseEvent の reason 文字列または SDK 内部のエラー分類コードのいずれかが入ることを明示する
- `src/base.ts` の 3 箇所 (`getSignalingWebSocket` の string 経路 onclose、`signaling` の onclose、`monitorSignalingWebSocketEvent` の onclose) で後付け代入を廃止し、constructor 引数で渡すように書き換える
- `src/base.ts` の `new ConnectError(message)` のみの 4 箇所 (`:1138`, `:1248`, `:1251`, `:1625`) は変更しない (いずれも第 1 引数で `message` を渡している)
- `tests/utils.test.ts` に `ConnectError` のテストを 4 件追加し、`import` を `ConnectError` と `createSignalingMessage` の統合形式に書き換える
- `CHANGES.md` の `### misc` セクションに `[UPDATE]` エントリを追記する

## 完了条件

- [x] `src/utils.ts` の `ConnectError` constructor を `(message: string, code?: number, reason?: string)` に拡張し、constructor 内で `this.code = code;` / `this.reason = reason;` を初期化する
- [x] `src/base.ts` の後付け代入 3 箇所で `new ConnectError(...)` に `code` / `reason` を引数で渡し、`error.code = ...` / `error.reason = ...` の 2 行を削除する
- [x] `src/base.ts` の `new ConnectError(message)` のみの 4 箇所は変更しない
- [x] `tests/utils.test.ts` 末尾に `ConnectError` のテストを追記する
- [x] `tests/utils.test.ts` の `import` を `ConnectError` と `createSignalingMessage` の統合形式に書き換える
- [x] ローカルで `pnpm test` が通る (76 件)
- [x] ローカルで `pnpm typecheck` が通る
- [x] ローカルで `pnpm lint` が通る
- [x] `CHANGES.md` の `## develop` `### misc` セクションに `[UPDATE]` エントリを追記する

## 関連 issue

- issues/closed/0021-refactor-connect-error-constructor.md