### PR TITLE
0009 切断系メソッド 5 経路で pc.onicecandidate を解除して Trickle ICE 由来の unhandled rejection を防ぐ

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
   - @voluntas
 - [FIX] iceConnectionState が disconnected で 10 秒経過した際の検知が現行ブラウザで動作していなかったのを修正する
   - @voluntas
+- [FIX] 切断系メソッド 5 経路で pc.onicecandidate を解除して Trickle ICE 由来の unhandled rejection を防ぐ
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0009-bug-fix-onicecandidate-not-cleared-after-disconnect.md
+++ b/issues/closed/0009-bug-fix-onicecandidate-not-cleared-after-disconnect.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-10
+- Completed: 2026-06-10
 - Model: Opus 4.7
 - Branch: feature/fix-onicecandidate-not-cleared
 
@@ -127,3 +128,33 @@ if (this.pc) {
 - **本 issue 自体は他 issue と独立に実装可能** (`ConnectError` も `clearPeerConnectionHandlers` も使わない 5 行追加。共通化は 0030 で扱う)
 - **本 issue の後続 (順序自由、本 issue とは独立に着手可能)**: 0008 / 0007 / 0034
 - **0030 への前進**: 0030 は 0009 / 0031 / 0042 / 0041 の 4 件すべてを必須先行依存に指定 (0030 line 13-20 の先行マージ前提 + line 373 の必須先行依存表)。本 issue マージ後さらに 0031 / 0042 / 0041 をマージしてから 0030 に進む
+
+## 解決方法
+
+切断系 5 経路すべてに `this.pc.onicecandidate = null;` を 1 行追加し、Trickle ICE 由来の unhandled rejection の発火源を断った。
+
+### `src/base.ts` 変更内容
+
+- `signalingTerminate()`: `if (this.pc) { ... }` ブロック内、`this.pc.close()` の **前** に `this.pc.onicecandidate = null;` を追加。`close()` 後 dispatch のレースを完全に消す目的と、他 4 ハンドラを置かない設計判断を 4 行の意図コメントで明示
+- `abendPeerConnectionState()`: 既存 4 ハンドラ null 化ブロック末尾 (`this.pc.onconnectionstatechange = null;` の直後) に `this.pc.onicecandidate = null;` を追加
+- `shutdown()`: 同位置に追加
+- `abend()`: 同位置に追加
+- `disconnect()`: `disconnectingPromise` ガード後の `try` ブロック内、同位置に追加
+
+### テスト
+
+- `pnpm test` (vitest) で既存単体テスト 76 件すべて通過を確認
+- E2E は本 issue「テスト方針」の方針通り追加せず、CI (`e2e-test.yml` 他) に委ねる
+
+### CHANGES.md
+
+`## develop` 直下の既存 `[FIX]` 群末尾 (`### misc` の前) に以下を追記:
+
+```
+- [FIX] 切断系メソッド 5 経路で pc.onicecandidate を解除して Trickle ICE 由来の unhandled rejection を防ぐ
+  - @voluntas
+```
+
+### レビュー結果
+
+`/review-diff-code` を 2 周実施。1 周目で出た重要指摘 (`signalingTerminate()` のコメント追加) を 1 周目内で反映し、2 周目で致命的・重要の追加指摘なしを確認。

--- a/src/base.ts
+++ b/src/base.ts
@@ -596,6 +596,11 @@ export default class ConnectionBase {
       this.ws = null;
     }
     if (this.pc) {
+      // close() より前に置く: close() 後に queue 済みの icecandidate イベントが
+      // dispatch されると sendSignalingMessage が CLOSING の ws/dc に send して
+      // unhandled rejection を起こすため、発火源を先に断つ。
+      // 他 4 ハンドラは sync で sendSignalingMessage を呼ばないためここでは null 化しない。
+      this.pc.onicecandidate = null;
       this.pc.close();
     }
     this.initializeConnection();
@@ -614,6 +619,7 @@ export default class ConnectionBase {
       this.pc.oniceconnectionstatechange = null;
       this.pc.onicegatheringstatechange = null;
       this.pc.onconnectionstatechange = null;
+      this.pc.onicecandidate = null;
     }
     if (this.ws) {
       // onclose はログを吐く専用に残す
@@ -677,6 +683,7 @@ export default class ConnectionBase {
       this.pc.oniceconnectionstatechange = null;
       this.pc.onicegatheringstatechange = null;
       this.pc.onconnectionstatechange = null;
+      this.pc.onicecandidate = null;
     }
 
     // DataChannel シグナリングの場合は停止する
@@ -725,6 +732,7 @@ export default class ConnectionBase {
       this.pc.oniceconnectionstatechange = null;
       this.pc.onicegatheringstatechange = null;
       this.pc.onconnectionstatechange = null;
+      this.pc.onicecandidate = null;
     }
     if (this.ws) {
       // onclose はログを吐く専用に残す
@@ -1068,6 +1076,7 @@ export default class ConnectionBase {
           this.pc.oniceconnectionstatechange = null;
           this.pc.onicegatheringstatechange = null;
           this.pc.onconnectionstatechange = null;
+          this.pc.onicecandidate = null;
         }
         // WebSocket の監視を止める
         if (this.ws) {


### PR DESCRIPTION
## 概要

切断系メソッド 5 経路で `pc.onicecandidate` ハンドラが解除されないまま `pc.close()` を実行していたため、close 後に dispatch される Trickle ICE candidate イベントが `sendSignalingMessage` 経由で CLOSING の WebSocket / DataChannel に send を試み、同期 throw → ハンドラの戻り Promise 破棄 → `unhandledrejection` イベント漏洩を引き起こしていた。発火源を断つために 5 経路すべてに `this.pc.onicecandidate = null;` を追加する。

詳細な経路分析と W3C webrtc-pc 仕様根拠は `issues/closed/0009-bug-fix-onicecandidate-not-cleared-after-disconnect.md` を参照。

## 変更内容

- `src/base.ts` の 5 経路に `this.pc.onicecandidate = null;` を追加
  - `signalingTerminate()`: `this.pc.close()` の **前** に追加し、close 後 dispatch のレースを完全に断つ意図と他 4 ハンドラを置かない設計判断を 4 行コメントで明示
  - `abendPeerConnectionState()` / `shutdown()` / `abend()` / `disconnect()`: 既存 4 ハンドラ null 化ブロックの末尾に追加 (0030 で `clearPeerConnectionHandlers()` に集約する想定で末尾配置)
- `CHANGES.md` の `## develop` 直下の `[FIX]` 群末尾にエントリを追記
- `issues/0009-...md` を `issues/closed/` に移動し「## 解決方法」セクションと `Completed: 2026-06-10` を追記

## 完了条件

- [x] `disconnect()` / `abend()` / `abendPeerConnectionState()` / `shutdown()` / `signalingTerminate()` の 5 経路に `this.pc.onicecandidate = null;` を追加 (4 経路は既存 null 化ブロック末尾、`signalingTerminate` は `pc.close()` の前)
- [x] ローカルで `pnpm test` が通る (vitest 単体テスト 76 件全件通過)
- [x] `pnpm e2e-test` は CI (`e2e-test.yml` 他) に委ねる
- [x] 単体テスト / E2E は追加しない (モック禁止規約 + 発火タイミング非決定性が理由、issue「テスト方針」参照)
- [x] CHANGES.md `## develop` 直下の既存 `[FIX]` 群末尾 (`### misc` の前) に FIX エントリを追記

## レビュー

`/review-diff-code` を 2 周実施。1 周目で出た重要指摘 (`signalingTerminate()` のコメント追加) を 1 周目内で反映し、2 周目で致命的・重要の追加指摘なしを確認。

## 関連 issue

- `issues/closed/0009-bug-fix-onicecandidate-not-cleared-after-disconnect.md`