### PR TITLE
0007 sendAnswer の ws.send が同期 throw したときに内部状態が dangling になるのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@
   - @voluntas
 - [FIX] 切断系メソッド 5 経路で pc.onicecandidate を解除して Trickle ICE 由来の unhandled rejection を防ぐ
   - @voluntas
+- [FIX] sendAnswer の ws.send が同期 throw したときに内部状態がクリーンアップされなかったのを修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0007-bug-fix-send-answer-ws-send-uncaught-exception.md
+++ b/issues/closed/0007-bug-fix-send-answer-ws-send-uncaught-exception.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-08
+- Completed: 2026-06-10
 - Model: Opus 4.7
 - Branch: feature/fix-send-answer-ws-send-exception
 
@@ -93,3 +94,11 @@ protected sendAnswer(): void {
   ```
 
 **マージ順:** `0021 → 0009 → 0001 → 0008 → 0007 → 0034` (0004 正本チェーン参照)。0021 (ConnectError constructor) が前提、0008 (onmessage 例外基盤) の後。
+
+## 解決方法
+
+`src/base.ts` の `sendAnswer` を設計方針どおり修正した。設計方針からの差分・追加判断のみここに記す。
+
+- `ConnectError` のメッセージプレフィックスを既存の `"Signaling failed. ..."` 系に揃え、両経路とも固定短文 (`"Signaling failed. Failed to send answer because WebSocket is not open"` / `"Signaling failed. Failed to send answer because ws.send threw"`) にする。失敗原因の識別は `reason` フィールドで行う設計に従い、message 側には `error.message` を埋め込まない (動的文字列の混入や reason との二重情報経路を避けるため)。
+- JSDoc には「他の send 系メソッド (`sendUpdateAnswer` / `sendReAnswer` など) は `sendSignalingMessage` を介して送信するため例外時の挙動が本メソッドとは対称ではない」と書き、issue 番号や「本 issue」の語は残さない。
+- `tests/utils.test.ts` に `WS_SEND_INVALID_STATE` / `WS_SEND_FAILED` を reason に持つ `ConnectError` 生成テストを `test.each` で並べ、sendAnswer 経路で投げる reason 値の存在を固定化する (検出範囲は reason 文字列のみ。message プレフィックスや sendAnswer 自体の振る舞いは AGENTS.md「モック禁止」 + jsdom に RTCPeerConnection 実装がない都合上、手動検証で担保する)。

--- a/src/base.ts
+++ b/src/base.ts
@@ -1527,14 +1527,47 @@ export default class ConnectionBase {
 
   /**
    * シグナリングサーバーに type answer を投げるメソッド
+   *
+   * WebSocket が OPEN 以外、または ws.send が同期例外を投げた場合は
+   * 内部状態 (ws / pc / soraDataChannels) が dangling のまま残らないように
+   * signalingTerminate() で同期的にクリーンアップしてから ConnectError を throw する。
+   * onclose の非同期発火に依存すると、呼び出し元が再 connect() するまでに
+   * 初期化が間に合わず、前回の残骸を踏んで状態破壊が連鎖し得るためである。
+   *
+   * 他の send 系メソッド (sendUpdateAnswer / sendReAnswer など) は sendSignalingMessage
+   * を介して送信するため例外時の挙動が本メソッドとは対称ではない (それらは現状
+   * try/catch せず Promise reject に委ねる)。
    */
   protected sendAnswer(): void {
     if (this.pc && this.ws && this.pc.localDescription) {
       this.trace("ANSWER SDP", this.pc.localDescription.sdp);
       const { sdp } = this.pc.localDescription;
       const message = { sdp, type: SIGNALING_MESSAGE_TYPE_ANSWER };
-      this.ws.send(JSON.stringify(message));
-      this.writeWebSocketSignalingLog("send-answer", message);
+      // readyState の表記は disconnectWebSocket と揃えて === 1 / !== 1 で比較する
+      if (this.ws.readyState !== 1) {
+        this.writeWebSocketSignalingLog("failed-to-send-answer", message);
+        this.signalingTerminate();
+        throw new ConnectError(
+          "Signaling failed. Failed to send answer because WebSocket is not open",
+          undefined,
+          "WS_SEND_INVALID_STATE",
+        );
+      }
+      // readyState が OPEN でも ws.send が同期 throw する可能性 (実装/環境依存) に
+      // 備えて try/catch で防御する。失敗原因は ConnectError.reason で識別する設計のため、
+      // message には個別の error 詳細を埋め込まない。
+      try {
+        this.ws.send(JSON.stringify(message));
+        this.writeWebSocketSignalingLog("send-answer", message);
+      } catch {
+        this.writeWebSocketSignalingLog("failed-to-send-answer", message);
+        this.signalingTerminate();
+        throw new ConnectError(
+          "Signaling failed. Failed to send answer because ws.send threw",
+          undefined,
+          "WS_SEND_FAILED",
+        );
+      }
     }
   }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -876,3 +876,15 @@ test("new ConnectError(message, undefined, reason) は reason のみを設定す
   expect(e.code).toBeUndefined();
   expect(e.reason).toBe("WS_SEND_FAILED");
 });
+
+// sendAnswer 経路 (src/base.ts) で投げる ConnectError の reason 値の存在を固定化する
+// (検出範囲は reason 文字列のみ。test name 中の %s は test.each で各値に置換される)
+test.each([["WS_SEND_INVALID_STATE"], ["WS_SEND_FAILED"]])(
+  "new ConnectError(message, undefined, %s) は sendAnswer 経路の reason を設定する",
+  (reason) => {
+    const e = new ConnectError("send answer failed", undefined, reason);
+    expect(e.message).toBe("send answer failed");
+    expect(e.code).toBeUndefined();
+    expect(e.reason).toBe(reason);
+  },
+);


### PR DESCRIPTION
## 概要

`sendAnswer` (`src/base.ts`) が `this.ws.send(JSON.stringify(message))` を try/catch せず同期呼び出ししていたため、`ws.readyState !== 1` 時に `InvalidStateError` が同期 throw されると `multiStream` が reject する一方で、SDK 内部状態 (`this.ws` / `this.pc` / `this.soraDataChannels`) のクリーンアップが ws の `onclose` ハンドラの非同期発火に依存していた。ユーザーが `connect()` の reject を catch して即座に再 `connect()` すると、前回の残骸を踏んで状態破壊が連鎖し得る不具合があった。

## 変更内容

- `sendAnswer` で `ws.readyState !== 1` を `send` の前に明示チェックし、該当時は `signalingTerminate()` で同期的にクリーンアップしてから `ConnectError` (reason `"WS_SEND_INVALID_STATE"`) を throw する。
- `ws.send` を try/catch で囲み、catch 時も `signalingTerminate()` で同期的にクリーンアップしてから `ConnectError` (reason `"WS_SEND_FAILED"`) を throw する。
- `ConnectError` のメッセージプレフィックスは既存の `"Signaling failed. ..."` 系に揃え、失敗原因の識別は `reason` フィールド (`"WS_SEND_INVALID_STATE"` / `"WS_SEND_FAILED"`) で行う設計に従う。
- `tests/utils.test.ts` に `test.each` で `WS_SEND_INVALID_STATE` / `WS_SEND_FAILED` を reason に持つ `ConnectError` 生成テストを追加する (検出範囲は reason 文字列のみ)。
- 関連 issue は `issues/closed/0007-...md` に移動し、`Completed: 2026-06-10` と `## 解決方法` セクションを追記。
- `CHANGES.md` の `## develop` に `[FIX]` エントリを追加。

## 完了条件

- [x] 設計方針どおり `sendAnswer` を修正する
- [x] 失敗経路で `writeWebSocketSignalingLog("failed-to-send-answer", message)` を残す
- [x] 失敗時に `signalingTerminate()` を呼んでから `ConnectError` (reason `"WS_SEND_INVALID_STATE"` / `"WS_SEND_FAILED"`) を throw する
- [x] ローカルで `pnpm test` (78 件 passed) および lint / typecheck / fmt が通る
- [x] CHANGES.md `## develop` に `[FIX]` エントリを追加

## 手動検証手順

`ws.readyState !== 1` の状況は TCP RST タイミング依存で E2E 自動化はスコープ外なため、自動テストは追加していない (`AGENTS.md`「モックやスタブは絶対に利用しないこと」と jsdom に `RTCPeerConnection` 実装がない都合上、`sendAnswer` の振る舞いを直接検証する unit test は実現不可)。手動検証は以下:

1. `createAnswer` 直後に Sora 側 TCP RST を強制する (`nc` 経由で TCP 接続を kill する 等) か、Chrome DevTools の Network パネルで WebSocket を kill して `ws.readyState` を OPEN 以外にする。
2. `connect()` が `ConnectError` (reason: `"WS_SEND_INVALID_STATE"` または `"WS_SEND_FAILED"`) で reject することを確認する。
3. その後 `this.ws` / `this.pc` / `this.soraDataChannels` がすべてクリアされていること (`signalingTerminate()` 経由) を timeline ログで確認する。
4. ユーザーが続けて `connect()` を再呼び出ししたとき、前回の残骸を踏まずに正常に再接続できることを確認する。

## スコープ外 (後続 issue で対応予定)

- `sendUpdateAnswer` / `sendReAnswer` / `sendSignalingMessage` / `signalingOnMessageTypePing` 等の他 send 系メソッドの同類修正は別 issue (0034) でまとめて扱う。
- `ConnectError` reason の定数化 (typo 防止) は別途検討。

## 関連 issue

- `issues/closed/0007-bug-fix-send-answer-ws-send-uncaught-exception.md`
- 依存 (マージ済み): 0021 (`ConnectError` constructor 拡張), 0009 (`onicecandidate` クリーンアップ)