### PR TITLE
0008 signaling() の ws.onmessage 内で例外が発生したときに connect() が connectionTimeout まで固まっていたのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@
   - @voluntas
 - [FIX] sendAnswer の ws.send が同期 throw したときに内部状態がクリーンアップされなかったのを修正する
   - @voluntas
+- [FIX] signaling() の ws.onmessage 内で例外が発生したときに connect() が connectionTimeout まで固まっていたのを修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0008-bug-fix-signaling-onmessage-exception-hangs-connect.md
+++ b/issues/closed/0008-bug-fix-signaling-onmessage-exception-hangs-connect.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-08
+- Completed: 2026-06-10
 - Model: Opus 4.7
 - Branch: feature/fix-signaling-onmessage-exception
 
@@ -182,3 +183,26 @@ return new Promise((resolve, reject) => {
 ## マージ順
 
 0004 正本チェーン `0004 → 0006 → (0011) → 0021 → 0009 → 0001 → 0008 → 0007 → 0034 → 0031 → 0002 → 0005 → 0030` の一部。0008 の前提は `0021 → 0009 → 0001` で 0021 (ConnectError constructor) と 0001 (同じ `signaling()` 関数を編集) が必須。0008 マージ後に `0007 → 0034 → 0031 → 0002 → 0005 → 0030` が続く。
+
+## 解決方法
+
+`src/base.ts` の `signaling()` 内 `ws.onmessage` を `try` / `catch` で囲み、`settled` フラグと `settleReject` クロージャを Promise executor 直下に導入した。pre-offer / post-offer の境界は各 `resolve` の直前で `settled = true` にすることで判別する。
+
+- pre-offer (settled === false) の throw: `signalingTerminate()` を呼び `ConnectError("Signaling failed. ws.onmessage threw: ...", undefined, "SIGNALING_ONMESSAGE_EXCEPTION")` で reject する。
+- post-offer (settled === true) の throw: ログ `onmessage-exception-post-offer` のみ出して接続中の ws / pc は破棄しない。
+- redirect 専用の内側 try/catch (`src/base.ts:1302-1307`) は撤去し、外側 catch に集約した。redirect 失敗時の reject 型は raw Error から ConnectError (reason: "SIGNALING_ONMESSAGE_EXCEPTION") に変わる。
+- `ws.onclose` ハンドラと `signalingMessage` 生成・`ws.send`・`this.ws` 設定ブロックは現状維持。NOTIFY 分岐の `writeWebSocketTimelineLog("notify-connection.created" / "notify-connection.destroyed", message)` 呼び出しも維持。
+
+`/review-diff-code` の指摘 (3 周分) を反映し、サンプル実装からの逸脱として以下を採用した。
+
+- pre-offer catch 内の順序を `settleReject(wrapped); writeWebSocketSignalingLog(...);` に変更した。`writeWebSocketSignalingLog` は内部で `this.callbacks.signaling` (ユーザコールバック) を呼ぶため、`settleReject` をログより先に呼ぶことで、ログ呼び出しが throw しても Promise の settle が保証される。
+- コメントから時間・コンテキスト依存表現 (「本 issue」「撤去した」「修正対象外」) を排除し、現在のコードの動作・設計判断を直接説明する形に揃えた。
+
+### 変更ファイル
+
+- `src/base.ts`: `signaling()` の `ws.onmessage` を try/catch で囲み、`settled` / `settleReject` を導入。redirect 専用 try/catch を撤去。
+- `CHANGES.md`: `## develop` の `[FIX]` 群末尾、`### misc` より前に追記。
+
+### テスト
+
+本 issue 専用のテストは追加しない。`tests/` 配下に signaling 関連テストは存在せず、`ws.onmessage` は `signaling()` 内ローカルクロージャで外部から差し替え不可能、CLAUDE.md「モックやスタブは絶対に利用しないこと」規約により単体テストでは検証できないため。既存 `pnpm test` (78 件) と `pnpm e2e-test` の非回帰確認のみで担保する。

--- a/src/base.ts
+++ b/src/base.ts
@@ -1281,6 +1281,23 @@ export default class ConnectionBase {
       this.writeWebSocketSignalingLog("new-websocket", ws.url);
       // websocket の各 callback を設定する
       ws.binaryType = "arraybuffer";
+      // signaling() の Promise が resolve / reject 済みかを追跡するフラグ。
+      // ws.onmessage 内で発生した例外を pre-offer / post-offer で分岐させるために使う。
+      // Promise コールバック内 (ws.onmessage の外) で定義しないと毎呼び出しでリセットされる。
+      let settled = false;
+      // settled が false のときに限り signalingTerminate() を呼んで reject する。
+      // 二重呼び出し時の二重 reject と二重 signalingTerminate を防ぐ。
+      const settleReject = (error: ConnectError): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.signalingTerminate();
+        reject(error);
+      };
+      // ws.onclose は settled を見ず、一律 signalingTerminate() + reject を呼ぶ。
+      // Promise の settle は最初の 1 回のみ有効なため、settleReject 経路と
+      // 二重 reject されても no-op になる (signalingTerminate() の冪等性に依存)。
       ws.onclose = (event): void => {
         const error = new ConnectError(
           `Signaling failed. CloseEventCode:${event.code} CloseEventReason:'${event.reason}'`,
@@ -1292,43 +1309,69 @@ export default class ConnectionBase {
         reject(error);
       };
       ws.onmessage = async (event): Promise<void> => {
-        if (typeof event.data !== "string") {
-          throw new TypeError("Received invalid signaling data");
-        }
-        const message = JSON.parse(event.data) as WebSocketSignalingMessage;
-        if (message.type === SIGNALING_MESSAGE_TYPE_OFFER) {
-          this.writeWebSocketSignalingLog("onmessage-offer", message);
-          this.signalingOnMessageTypeOffer(message);
-          this.connectedSignalingUrl = ws.url;
-          resolve(message);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_UPDATE) {
-          this.writeWebSocketSignalingLog("onmessage-update", message);
-          await this.signalingOnMessageTypeUpdate(message);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_RE_OFFER) {
-          this.writeWebSocketSignalingLog("onmessage-re-offer", message);
-          await this.signalingOnMessageTypeReOffer(message);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_PING) {
-          await this.signalingOnMessageTypePing(message);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_PUSH) {
-          this.callbacks.push(message, TRANSPORT_TYPE_WEBSOCKET);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_NOTIFY) {
-          if (message.event_type === "connection.created") {
-            this.writeWebSocketTimelineLog("notify-connection.created", message);
-          } else if (message.event_type === "connection.destroyed") {
-            this.writeWebSocketTimelineLog("notify-connection.destroyed", message);
+        try {
+          if (typeof event.data !== "string") {
+            throw new TypeError("Received invalid signaling data");
           }
-          this.signalingOnMessageTypeNotify(message, TRANSPORT_TYPE_WEBSOCKET);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_SWITCHED) {
-          this.writeWebSocketSignalingLog("onmessage-switched", message);
-          this.signalingOnMessageTypeSwitched(message);
-        } else if (message.type === SIGNALING_MESSAGE_TYPE_REDIRECT) {
-          this.writeWebSocketSignalingLog("onmessage-redirect", message);
-          try {
+          const message = JSON.parse(event.data) as WebSocketSignalingMessage;
+          if (message.type === SIGNALING_MESSAGE_TYPE_OFFER) {
+            this.writeWebSocketSignalingLog("onmessage-offer", message);
+            this.signalingOnMessageTypeOffer(message);
+            this.connectedSignalingUrl = ws.url;
+            // resolve 直前で settled を true にする。ここまでで throw した場合は
+            // settled === false のまま catch に入り pre-offer reject される。
+            settled = true;
+            resolve(message);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_UPDATE) {
+            this.writeWebSocketSignalingLog("onmessage-update", message);
+            await this.signalingOnMessageTypeUpdate(message);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_RE_OFFER) {
+            this.writeWebSocketSignalingLog("onmessage-re-offer", message);
+            await this.signalingOnMessageTypeReOffer(message);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_PING) {
+            await this.signalingOnMessageTypePing(message);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_PUSH) {
+            this.callbacks.push(message, TRANSPORT_TYPE_WEBSOCKET);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_NOTIFY) {
+            if (message.event_type === "connection.created") {
+              this.writeWebSocketTimelineLog("notify-connection.created", message);
+            } else if (message.event_type === "connection.destroyed") {
+              this.writeWebSocketTimelineLog("notify-connection.destroyed", message);
+            }
+            this.signalingOnMessageTypeNotify(message, TRANSPORT_TYPE_WEBSOCKET);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_SWITCHED) {
+            this.writeWebSocketSignalingLog("onmessage-switched", message);
+            this.signalingOnMessageTypeSwitched(message);
+          } else if (message.type === SIGNALING_MESSAGE_TYPE_REDIRECT) {
+            this.writeWebSocketSignalingLog("onmessage-redirect", message);
+            // redirect 失敗時は外側 catch で ConnectError
+            // (reason: "SIGNALING_ONMESSAGE_EXCEPTION") として reject される。
             const redirectMessage = await this.signalingOnMessageTypeRedirect(message);
+            settled = true;
             resolve(redirectMessage);
-          } catch (error) {
-            reject(error instanceof Error ? error : new Error(String(error)));
           }
+          // 未知の message.type は no-op (offer 待ちを継続)
+        } catch (error) {
+          if (settled) {
+            // post-offer: 接続中の ws / pc を破棄せずログのみで握りつぶす。
+            // signalingTerminate を呼ぶと正常接続が壊れるため呼ばない。
+            this.writeWebSocketSignalingLog(
+              "onmessage-exception-post-offer",
+              (error as Error).message,
+            );
+            return;
+          }
+          // pre-offer: ConnectError でラップして signalingTerminate + reject する。
+          const wrapped = new ConnectError(
+            `Signaling failed. ws.onmessage threw: ${(error as Error).message}`,
+            undefined,
+            "SIGNALING_ONMESSAGE_EXCEPTION",
+          );
+          // writeWebSocketSignalingLog は this.callbacks.signaling を呼ぶため、
+          // ユーザコールバック throw でこの行自体が失敗しうる。
+          // Promise の settle を最優先するため settleReject をログより先に呼ぶ。
+          settleReject(wrapped);
+          this.writeWebSocketSignalingLog("onmessage-exception-pre-offer", wrapped.message);
         }
       };
       let signalingMessage: SignalingConnectMessage;


### PR DESCRIPTION
## 概要

`signaling()` (`src/base.ts`) の `ws.onmessage` が async クロージャだが try/catch されておらず、`typeof event.data !== "string"` での `throw new TypeError`、`JSON.parse` の `SyntaxError`、各 `signalingOnMessageType*` の reject が、`signaling()` を包む `new Promise((resolve, reject) => ...)` の `reject` に届かなかった (WebSocket dispatcher は async `onmessage` の戻り値 Promise を捕捉せず unhandled rejection になるだけ)。結果として `connect()` が `setConnectionTimeout` のタイマー発火 (デフォルト 60000ms、0 なら無限) まで固まる経路を塞ぐ。

## 変更内容

- `src/base.ts` の `signaling()` 内 `ws.onmessage` を try/catch で囲み、`settled` フラグと `settleReject` クロージャを Promise executor 直下に導入する
- pre-offer (settled === false) の throw は `signalingTerminate()` + `ConnectError` (reason: `"SIGNALING_ONMESSAGE_EXCEPTION"`) で reject する
- post-offer (settled === true) の throw はログ `onmessage-exception-post-offer` のみ出して接続中の ws / pc を破棄しない
- redirect 専用の内側 try/catch (`src/base.ts:1302-1307`) を撤去し外側 catch に集約する
- pre-offer catch 内は `settleReject(wrapped)` をログより先に呼ぶ。`writeWebSocketSignalingLog` は内部で `this.callbacks.signaling` を呼び、ユーザコールバック throw でログ自体が失敗しうるため、Promise の settle を最優先する
- `CHANGES.md` の `## develop` の `[FIX]` 群末尾に追記する

## 完了条件

- [x] 上記サンプル実装の設計意図どおりに `settled` / `settleReject` を導入し、pre-offer throw 時に `signalingTerminate()` + `reject(ConnectError)` する
- [x] `settled = true` を各 `resolve` の直前に置く
- [x] post-offer throw では `signalingTerminate()` を呼ばずログ `onmessage-exception-post-offer` のみ
- [x] pre-offer throw はログ `onmessage-exception-pre-offer` を出してから `settleReject(wrapped)` を呼ぶ (注: ログ throw への耐性のため `settleReject` を先に呼ぶ順序に変更している)
- [x] redirect 専用の内側 try/catch を撤去し外側 try に集約する
- [x] NOTIFY 分岐の `writeWebSocketTimelineLog` 呼び出しを維持する
- [x] `ws.onclose` ハンドラおよび `signalingMessage` 生成・`ws.send`・`this.ws` 設定ブロックは現状維持
- [x] ローカルで `pnpm test` (78 件 passed) が通ること
- [x] `CHANGES.md` `## develop` の既存 `[FIX]` 群の末尾、`### misc` より前に追記

## 関連 issue

- `issues/closed/0008-bug-fix-signaling-onmessage-exception-hangs-connect.md`