### PR TITLE
0010 generateCertificate 失敗時に fallback がなく接続不可になるのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
   - @voluntas
 - [FIX] signaling() の ws.onmessage 内で例外が発生したときに connect() が connectionTimeout まで固まっていたのを修正する
   - @voluntas
+- [FIX] generateCertificate が失敗した環境 (FIPS モード等) でも接続できるようにフォールバックする
+  - @voluntas
 
 ### misc
 
@@ -57,6 +59,8 @@
   - `.oxlintrc.jsonc` と `.oxfmtrc.jsonc` を削除する
   - @voluntas
 - [UPDATE] 内部 ConnectError の constructor で code と reason を引数として受け取れるようにし base.ts の後付け代入を廃止する
+  - @voluntas
+- [UPDATE] Algorithm 型のグローバル拡張を削除し generateCertificate の引数型を EcKeyGenParams に置き換える
   - @voluntas
 - [FIX] Node 24 で `playwright install` がハングする問題を修正するため Playwright を 1.60.0 に更新する
   - @voluntas

--- a/issues/closed/0010-bug-fix-generate-certificate-no-fallback.md
+++ b/issues/closed/0010-bug-fix-generate-certificate-no-fallback.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-21
+- Completed: 2026-06-10
 - Polished: 2026-06-08
 - Model: Opus 4.7
 - Branch: feature/fix-generate-certificate-fallback
@@ -91,3 +92,17 @@ if (window.RTCPeerConnection.generateCertificate !== undefined) {
   - [UPDATE] Algorithm 型のグローバル拡張を削除し generateCertificate の引数型を EcKeyGenParams に置き換える
     - @voluntas
   ```
+
+## 解決方法
+
+`src/base.ts` の以下を変更した。
+
+- `connectPeerConnection` (`src/base.ts:1404-1416`) の `generateCertificate` 呼び出しを try/catch で囲み、`generateCertificate` が reject した場合は `config.certificates` を設定せずブラウザデフォルトの証明書で `new RTCPeerConnection` に進むフォールバックを実装した。catch では `this.trace("GENERATE CERTIFICATE FAILED", reason)` と `this.writePeerConnectionTimelineLog("generate-certificate-failed", { reason })` でログを残す。`reason` は `String(error)` で文字列化したものを使い回す。
+  - trace title は既存の「大文字 + 半角スペース区切り」命名慣習 (例: `"PEER CONNECTION CONFIG"`, `"CREATE OFFER"`) に合わせて `"GENERATE CERTIFICATE FAILED"` (スペース区切り) とした。`/review-diff-code` の指摘で issue 本文記載の `"GENERATE-CERTIFICATE-FAILED"` (ハイフン区切り) は既存の trace title 全 21 件と整合しないことが判明したため、issue の記載とは異なる形に修正した。
+  - catch 変数名は既存の他 catch ブロックに合わせて `error` とした (issue 本文は `e` 記載だったが、`src/base.ts` 内の他 10 箇所の catch がいずれも `error` であるため統一)。
+- `declare global { interface Algorithm { namedCurve: string; } }` (`src/base.ts:80-84`) を削除した。
+- `generateCertificate` の引数を型注釈付きローカル変数 `const keygenAlgorithm: EcKeyGenParams = { name: "ECDSA", namedCurve: "P-256" }` に切り出し、`EcKeyGenParams` (`lib.dom.d.ts` 標準) を使って渡すことで、グローバル拡張なしで型エラーを回避した。
+
+テスト追加は行わなかった (issue 完了条件の方針通り)。代わりに DevTools console で `window.RTCPeerConnection.generateCertificate = () => Promise.reject(new DOMException("test", "NotSupportedError"))` に差し替えた状態で `connect()` が成立することを確認する検証手順を PR 本文に記載する。
+
+`pnpm typecheck` (`tsc --noEmit`) と `pnpm test` (vitest) はローカルで通過。e2e-test は CI で確認する。

--- a/src/base.ts
+++ b/src/base.ts
@@ -77,12 +77,6 @@ import {
   trace,
 } from "./utils";
 
-declare global {
-  interface Algorithm {
-    namedCurve: string;
-  }
-}
-
 /**
  * Sora との WebRTC 接続を扱う基底クラス
  *
@@ -1410,11 +1404,16 @@ export default class ConnectionBase {
   protected async connectPeerConnection(message: SignalingOfferMessage): Promise<void> {
     let config = { ...message.config };
     if (window.RTCPeerConnection.generateCertificate !== undefined) {
-      const certificate = await window.RTCPeerConnection.generateCertificate({
-        name: "ECDSA",
-        namedCurve: "P-256",
-      });
-      config = { certificates: [certificate], ...config };
+      // FIPS モード等で generateCertificate が失敗する環境でも接続を継続できるようフォールバックする
+      try {
+        const keygenAlgorithm: EcKeyGenParams = { name: "ECDSA", namedCurve: "P-256" };
+        const certificate = await window.RTCPeerConnection.generateCertificate(keygenAlgorithm);
+        config = { certificates: [certificate], ...config };
+      } catch (error) {
+        const reason = String(error);
+        this.trace("GENERATE CERTIFICATE FAILED", reason);
+        this.writePeerConnectionTimelineLog("generate-certificate-failed", { reason });
+      }
     }
     this.trace("PEER CONNECTION CONFIG", config);
     this.writePeerConnectionTimelineLog("new-peerconnection", config);


### PR DESCRIPTION
## 概要

`connectPeerConnection` で `window.RTCPeerConnection.generateCertificate({ name: "ECDSA", namedCurve: "P-256" })` を try/catch なしで `await` していたため、FIPS モード Chromium や企業 PC のセキュリティポリシー等で `NotSupportedError` / `OperationError` が返ると `connect()` 全体が失敗していた。証明書生成に失敗してもブラウザデフォルトの証明書で接続を継続できるようフォールバックする。あわせて WebCrypto 標準型を直接使えるようにするため、`declare global { interface Algorithm { namedCurve: string; } }` による型汚染を削除する。

## 変更内容

- `src/base.ts` の `connectPeerConnection` 内の `generateCertificate` 呼び出しを try/catch で囲み、reject 時は `config.certificates` を設定せずブラウザデフォルトの証明書で `new RTCPeerConnection` に進むフォールバックを実装する。catch では `this.trace("GENERATE CERTIFICATE FAILED", reason)` と `this.writePeerConnectionTimelineLog("generate-certificate-failed", { reason })` でログを残す
- trace title は既存の trace title (全 21 件は大文字+半角スペース区切り) に合わせて `"GENERATE CERTIFICATE FAILED"` とする (issue 本文の `"GENERATE-CERTIFICATE-FAILED"` 記載は `/review-diff-code` の指摘で既存命名と整合しないことが判明したため修正)
- catch 変数名は既存の他 catch ブロックに合わせて `error` とする
- `String(error)` で文字列化したものを `const reason` に集約し、trace と timeline で同じ値を使う (`DOMException` 等 非 Error の reject 値もカバーするため `String()` を採用)
- `src/base.ts:80-84` の `declare global { interface Algorithm { namedCurve: string; } }` を削除
- `generateCertificate` の引数を型注釈付きローカル変数 `const keygenAlgorithm: EcKeyGenParams = { name: "ECDSA", namedCurve: "P-256" }` に切り出して渡す (`EcKeyGenParams` は `lib.dom.d.ts` 標準で import 不要)

## 後方互換性に関する注意

`declare global { interface Algorithm { namedCurve: string; } }` は `dist/base.d.ts` 経由で npm 配布時に SDK 利用者の `Algorithm` 型に注入されていた。本 PR でこの拡張を削除すると、SDK 利用者が `Algorithm.namedCurve` を直接参照していた場合に型エラーになる。ただし WebCrypto 標準では `Algorithm` ではなく `EcKeyGenParams` を使うのが正しいため、`Algorithm.namedCurve` を直接参照しているユーザーコードは想定し難く、影響は極小と判断して `[UPDATE]` (後方互換あり) として記載する。

## 限界

完全な FIPS モードでは `new RTCPeerConnection(config)` 自体が DTLS 内部 ECDSA 鍵生成で失敗する可能性があり、本 fix では救えない。本 fix が救うのは「`generateCertificate` のみが特異的に失敗し `new RTCPeerConnection` 自体はブラウザデフォルト証明書で成立する環境」のみ。

## 完了条件

- [x] `connectPeerConnection` で `generateCertificate` を try/catch で囲み、catch 時は `config.certificates` を設定せずに進む
- [x] `this.trace("GENERATE CERTIFICATE FAILED", reason)` と `this.writePeerConnectionTimelineLog("generate-certificate-failed", { reason })` でログを残す
- [x] `src/base.ts:80-84` の `declare global { interface Algorithm { namedCurve: string; } }` を削除
- [x] `generateCertificate` の引数を型注釈付きローカル変数 `EcKeyGenParams` に切り出して渡す
- [x] `pnpm typecheck` (`tsc --noEmit`) が通る
- [x] `pnpm test` (vitest) が通る
- [ ] `pnpm e2e-test` が CI で通る
- [x] CHANGES.md `## develop` に `[FIX]` と `### misc` の `[UPDATE]` を追記
- [x] DevTools console での検証手順を PR 本文に記載

## 検証手順 (DevTools console)

実際の FIPS モード Chromium / 企業 PC 環境の再現が困難なため、DevTools console で `generateCertificate` を一時的にエラー throw に差し替えて挙動を確認する。

1. `pnpm e2e-dev` で e2e サンプル (sendrecv 等) のページを開く
2. DevTools console で以下を実行
   ```js
   window.RTCPeerConnection.generateCertificate = () => Promise.reject(new DOMException("test", "NotSupportedError"));
   ```
3. 通常通り `connect()` を実行
4. 期待挙動
   - `connect()` が成立する (= reject しない)
   - `callbacks.log` に `GENERATE CERTIFICATE FAILED` が `NotSupportedError: test` 付きで記録される
   - `callbacks.timeline` に `generate-certificate-failed` イベントが `{ reason: "NotSupportedError: test" }` 付きで記録される
   - その後の `new-peerconnection` ログ以降の接続フローが通常通り進む

## 関連 issue

- issues/closed/0010-bug-fix-generate-certificate-no-fallback.md