### PR TITLE
0012 removeAudioTrack / removeVideoTrack が disconnect レース時に無言で resolve していたのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - Node 20 は 2026-04-30 に EoL になったため
   - <https://github.com/nodejs/Release#release-schedule>
   - @voluntas
+- [CHANGE] `removeAudioTrack` / `removeVideoTrack` 実行中に `disconnect()` 等で `RTCPeerConnection` が破棄された場合に `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject するように変更する
+  - 利用者は `.catch` で reject を受ける必要がある (fire-and-forget で呼んでいる場合は unhandled promise rejection が発生する)
+  - 非推奨の `stopAudioTrack` / `stopVideoTrack`、および `replaceAudioTrack` / `replaceVideoTrack` 経由でも同じ reject が伝播する
+  - @voluntas
 - [UPDATE] pnpm 11 系に上げる
   - @voluntas
 - [UPDATE] TypeScript 6.0 へ対応する

--- a/issues/closed/0012-bug-fix-remove-track-race-with-disconnect.md
+++ b/issues/closed/0012-bug-fix-remove-track-race-with-disconnect.md
@@ -3,6 +3,7 @@
 - Priority: Low
 - Created: 2026-05-21
 - Polished: 2026-06-08
+- Completed: 2026-06-11
 - Model: Opus 4.7
 - Branch: feature/change-remove-track-race-with-disconnect
 
@@ -130,3 +131,14 @@ reject 時点で以下の状態が利用者から観測される:
 ## マージ順
 
 **0021 → 0012**。0021 の `ConnectError` constructor (3 引数形式) が前提。0021 が `issues/pending/` に移動した場合は 0012 も同時に pending 化する (本 issue 単独で先行マージしない)。0012 は `removeXxxTrack` のみ編集し他 issue とファイル競合しないため 0004 正本チェーンには組み込まない (詳細は 0004 参照)。リリース単位としては `## develop` で 0004 系と同梱される。
+
+## 解決方法
+
+`src/base.ts` の `removeAudioTrack` と `removeVideoTrack` の `setTimeout` コールバック先頭に `this.pc === null` ガードを追加し、null 化されていれば既存処理 (`track.stop()` / `stream.removeTrack(track)` / `replaceTrack(null)`) を一切実行せず `ConnectError` で reject するようにした。
+
+- `src/base.ts:423-432` (`removeAudioTrack`) と `src/base.ts:513-522` (`removeVideoTrack`) に先頭ガードを追加。reject 引数は `new ConnectError("Disconnected during removeAudioTrack", undefined, "REMOVE_TRACK_DURING_DISCONNECT")` (video 側は `"Disconnected during removeVideoTrack"`) で、reason は両関数共通の `"REMOVE_TRACK_DURING_DISCONNECT"`、`error.message` のプレフィックスで個別操作を判別できるようにした
+- 100ms ディレイ・先行 `enabled = false` ループ・既存 `if (this.pc !== null)` 内側ガード・`removeVideoTrack` 側の `// replaceTrack は非同期操作なので catch(reject) しておく` コメントはすべて維持した
+- 公開 API の後方互換破壊を利用者に伝えるため、`stopAudioTrack` / `removeAudioTrack` / `stopVideoTrack` / `removeVideoTrack` / `replaceAudioTrack` / `replaceVideoTrack` の 6 メソッドの `@remarks` に reject 経路 (`ConnectError` reason `"REMOVE_TRACK_DURING_DISCONNECT"`) を追記した。`@throws` タグは SDK 既存 TSDoc スタイルから外れるため使わず、既存 `@remarks` 記法に揃えた
+- 本 issue 専用テストは追加しなかった (issue §検証 に従い、jsdom 環境で `this.pc` を自然に null 化するテストは書けないため、先頭ガードの到達性はコードレビューで担保)
+- `CHANGES.md` の `## develop` セクション、`[CHANGE]` 群末尾・`### misc` より前に `[CHANGE]` エントリを追記した
+- ローカルで `pnpm test` (78 tests passed) を確認した

--- a/src/base.ts
+++ b/src/base.ts
@@ -374,7 +374,9 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の audio track を停止後、PeerConnection の senders から対象の sender を削除します
+   * stream の audio track を停止後、PeerConnection の senders から対象の sender を削除します。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します
    *
    * @param stream - audio track を削除する MediaStream
    *
@@ -403,7 +405,9 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の audio track を停止後、PeerConnection の senders から対象の sender を削除します
+   * stream の audio track を停止後、PeerConnection の senders から対象の sender を削除します。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します
    *
    * @param stream - audio track を削除する MediaStream
    *
@@ -416,6 +420,16 @@ export default class ConnectionBase {
     return new Promise((resolve, reject) => {
       // すぐに stop すると視聴側に静止画像が残ってしまうので enabled false にした 100ms 後に stop する
       setTimeout(() => {
+        if (this.pc === null) {
+          reject(
+            new ConnectError(
+              "Disconnected during removeAudioTrack",
+              undefined,
+              "REMOVE_TRACK_DURING_DISCONNECT",
+            ),
+          );
+          return;
+        }
         const promises = stream.getAudioTracks().map(async (track) => {
           track.stop();
           stream.removeTrack(track);
@@ -450,7 +464,9 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の video track を停止後、PeerConnection の senders から対象の sender を削除します
+   * stream の video track を停止後、PeerConnection の senders から対象の sender を削除します。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します
    *
    * @param stream - video track を停止する MediaStream
    *
@@ -479,7 +495,9 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の video track を停止後、PeerConnection の senders から対象の sender を削除します
+   * stream の video track を停止後、PeerConnection の senders から対象の sender を削除します。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します
    *
    * @param stream - video track を削除する MediaStream
    *
@@ -492,6 +510,16 @@ export default class ConnectionBase {
     return new Promise((resolve, reject) => {
       // すぐに stop すると視聴側に静止画像が残ってしまうので enabled false にした 100ms 後に stop する
       setTimeout(() => {
+        if (this.pc === null) {
+          reject(
+            new ConnectError(
+              "Disconnected during removeVideoTrack",
+              undefined,
+              "REMOVE_TRACK_DURING_DISCONNECT",
+            ),
+          );
+          return;
+        }
         const promises = stream.getVideoTracks().map(async (track) => {
           track.stop();
           stream.removeTrack(track);
@@ -526,7 +554,10 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の audio track を停止後、新しい audio track をセットします
+   * stream の audio track を停止後、新しい audio track をセットします。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します。
+   * このとき新しい `audioTrack` は `stream` に追加されないため、呼び出し元側で `audioTrack.stop()` を呼んでください
    *
    * @param stream - audio track を削除する MediaStream
    * @param audioTrack - 新しい audio track
@@ -557,7 +588,10 @@ export default class ConnectionBase {
    * ```
    *
    * @remarks
-   * stream の video track を停止後、新しい video track をセットします
+   * stream の video track を停止後、新しい video track をセットします。
+   * 内部で 100ms 待機する間に `disconnect()` / `abend()` 等で `RTCPeerConnection` が破棄された場合は、
+   * `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject します。
+   * このとき新しい `videoTrack` は `stream` に追加されないため、呼び出し元側で `videoTrack.stop()` を呼んでください
    *
    * @param stream - video track を削除する MediaStream
    * @param videoTrack - 新しい video track


### PR DESCRIPTION
## 概要

`removeAudioTrack` / `removeVideoTrack` は 100ms 待機中に `disconnect()` / `abend()` 等で `this.pc` が `null` に初期化されると、sender クリーンアップだけスキップされた状態で `resolve()` していた。利用者からは正常終了と区別がつかず誤解を招くため、disconnect レース時には `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject するように変更する。後方互換破壊のため `[CHANGE]` 扱い。

## 変更内容

- `src/base.ts` の `removeAudioTrack` / `removeVideoTrack` の `setTimeout` コールバック先頭に `this.pc === null` ガードを追加し、null 時は `track.stop()` / `stream.removeTrack(track)` / `replaceTrack(null)` を実行せずに `ConnectError` で reject する
- reject 引数: `new ConnectError("Disconnected during removeXxxTrack", undefined, "REMOVE_TRACK_DURING_DISCONNECT")`。reason は両関数共通で、`error.message` のプレフィックスで個別操作を判別する
- 100ms ディレイ・先行 `enabled = false` ループ・既存の `if (this.pc !== null)` 内側ガード・`removeVideoTrack` 側の `// replaceTrack は非同期操作なので catch(reject) しておく` コメントは維持
- `stopAudioTrack` / `removeAudioTrack` / `stopVideoTrack` / `removeVideoTrack` / `replaceAudioTrack` / `replaceVideoTrack` の 6 メソッドの `@remarks` に reject 経路を追記
- `CHANGES.md` の `## develop` セクション、`[CHANGE]` 群末尾・`### misc` より前に `[CHANGE]` エントリを追記
- issue 0012 を `issues/closed/` に移動し、`Completed: 2026-06-11` と「## 解決方法」を追記

## 完了条件

- [x] `removeAudioTrack` / `removeVideoTrack` の `setTimeout` 先頭で `this.pc === null` 検知時に `ConnectError` (reason `"REMOVE_TRACK_DURING_DISCONNECT"`) で reject し、破壊操作 (`track.stop()` / `stream.removeTrack(track)` / `replaceTrack(null)`) を行わない
- [x] 100ms ディレイと先行 `enabled = false` ループを維持
- [x] `replaceAudioTrack` / `replaceVideoTrack` / `stopAudioTrack` / `stopVideoTrack` のコード本体は変更せず、`removeXxxTrack` の reject を素通しする
- [x] 既存コメント (`// replaceTrack は非同期操作なので catch(reject) しておく` 等) を維持
- [x] `pnpm test` が pass (78 tests passed)
- [x] `CHANGES.md` `## develop` に `[CHANGE]` エントリを追記

## 関連 issue

- `issues/closed/0012-bug-fix-remove-track-race-with-disconnect.md`
- 前提: 0021 (`ConnectError` constructor 3 引数化)。マージ済み (#724)

## 手動検証手順

本 issue 専用テストは追加していない (CLAUDE.md 「モックやスタブは絶対に利用しないこと」規約により jsdom で `this.pc` を自然に null 化する経路がないため、先頭ガードの到達性はコードレビューで担保)。利用者影響を確認するには、Firefox / Chrome で multistream connection を作り、`removeAudioTrack(stream)` を `await` しながら 100ms 以内に `disconnect()` を呼び、reject の `error.reason === "REMOVE_TRACK_DURING_DISCONNECT"` が捕捉できることを確認する。