### PR TITLE
0031 disconnect() が DataChannel 切断エラー時の abend event を normal で上書きするのを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@
   - @voluntas
 - [FIX] generateCertificate が失敗した環境 (FIPS モード等) でも接続できるようにフォールバックする
   - @voluntas
+- [FIX] disconnect() で DataChannel 切断エラー (code 4999) 時に abend event が normal で上書きされないようにする
+  - @voluntas
 
 ### misc
 

--- a/e2e-tests/data_channel_signaling_only/index.html
+++ b/e2e-tests/data_channel_signaling_only/index.html
@@ -21,6 +21,8 @@
       <div id="signaling-type-switched"></div>
       <div id="api-disconnect-status"></div>
       <div id="signaling-close-type"></div>
+      <div id="disconnect-event-type"></div>
+      <div id="disconnect-event-reason"></div>
       <video
         id="local-video"
         autoplay=""

--- a/e2e-tests/data_channel_signaling_only/main.ts
+++ b/e2e-tests/data_channel_signaling_only/main.ts
@@ -8,6 +8,7 @@ import type {
   SignalingNotifyConnectionCreated,
   SignalingNotifyMessage,
   SignalingSwitchedMessage,
+  SoraCloseEvent,
   SoraConnection,
 } from "sora-js-sdk";
 
@@ -19,6 +20,17 @@ document.addEventListener("DOMContentLoaded", async () => {
   const apiUrl = import.meta.env.VITE_TEST_API_URL;
 
   setSoraJsSdkVersion();
+
+  // URL クエリから disconnectWaitTimeout を読む
+  // `null` のときだけ undefined を返し、それ以外 (`"0"` を含む) は parseInt する。
+  // `if (v)` で `"0"` を握り潰さないために `=== null` で明示判定する。
+  const disconnectWaitTimeoutParam = new URLSearchParams(location.search).get(
+    "disconnectWaitTimeout",
+  );
+  const disconnectWaitTimeout =
+    disconnectWaitTimeoutParam === null
+      ? undefined
+      : Number.parseInt(disconnectWaitTimeoutParam, 10);
 
   let client: SoraClient;
 
@@ -41,6 +53,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       secretKey,
       channelName,
       apiUrl,
+      disconnectWaitTimeout,
     );
     await client.connect(stream);
   });
@@ -86,11 +99,7 @@ class SoraClient {
   private readonly debug = false;
   private readonly channelId: string;
   private readonly metadata: { access_token: string };
-  private readonly options: ConnectionOptions = {
-    connectionTimeout: 15_000,
-    dataChannelSignaling: true,
-    ignoreDisconnectWebSocket: true,
-  };
+  private readonly options: ConnectionOptions;
 
   private readonly sora: SoraConnection;
   private readonly connection: ConnectionPublisher;
@@ -104,8 +113,21 @@ class SoraClient {
     secretKey: string,
     channelName: string,
     apiUrl: string,
+    disconnectWaitTimeout?: number,
   ) {
     this.apiUrl = apiUrl;
+
+    // 既存のハードコード値に disconnectWaitTimeout だけを差し込む
+    // 未指定 (`undefined`) の場合は SDK 既定値 (3000ms) に委ねる
+    const options: ConnectionOptions = {
+      connectionTimeout: 15_000,
+      dataChannelSignaling: true,
+      ignoreDisconnectWebSocket: true,
+    };
+    if (disconnectWaitTimeout !== undefined) {
+      options.disconnectWaitTimeout = disconnectWaitTimeout;
+    }
+    this.options = options;
 
     this.sora = Sora.connection(signalingUrl, this.debug);
 
@@ -118,6 +140,7 @@ class SoraClient {
     this.connection.on("notify", this.onNotify.bind(this));
     this.connection.on("connected", this.onConnected.bind(this));
     this.connection.on("switched", this.onSwitched.bind(this));
+    this.connection.on("disconnect", this.onDisconnect.bind(this));
 
     // E2E テスト用のコード
     this.connection.on("signaling", this.onSignaling.bind(this));
@@ -175,6 +198,22 @@ class SoraClient {
     const switchedStatusElement = document.querySelector("#switched-status");
     if (switchedStatusElement) {
       switchedStatusElement.textContent = "switched";
+    }
+  }
+
+  // disconnect コールバック
+  // E2E テストから event.type / event.reason を assert するために DOM に出力する。
+  // 注意: handler 二重登録禁止。後続 issue (0002) で disconnect 回数を数える処理を
+  // 追加する場合も、新規 handler を作らず本メソッド内に処理を統合すること。
+  private onDisconnect(event: SoraCloseEvent): void {
+    console.log("[disconnect]", event);
+    const disconnectEventTypeElement = document.querySelector("#disconnect-event-type");
+    if (disconnectEventTypeElement) {
+      disconnectEventTypeElement.textContent = event.type;
+    }
+    const disconnectEventReasonElement = document.querySelector("#disconnect-event-reason");
+    if (disconnectEventReasonElement) {
+      disconnectEventReasonElement.textContent = event.reason ?? "";
     }
   }
 

--- a/e2e-tests/tests/disconnect_event_type.test.ts
+++ b/e2e-tests/tests/disconnect_event_type.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { checkSoraVersion, unsupportedVersionSkipReason } from "./helper";
+
+// disconnect() の signalingSwitched === true 経路で、disconnectDataChannel() が
+// `{ code: 4999 }` を返したときに event を normal で上書きせず abend として
+// アプリへ通知することを確認する E2E テスト。
+//
+// 再現条件:
+// - data_channel_signaling_only fixture (`ignoreDisconnectWebSocket: true`、`dataChannelSignaling: true`)
+// - `disconnectWaitTimeout=0` を URL クエリで渡し、`disconnect()` 内の
+//   `Promise.race` を timeout 側に確実に倒す。これにより `disconnectDataChannel()` の
+//   catch (`reason: "DISCONNECT-WAIT-TIMEOUT-ERROR"`) を踏ませて code 4999 を返させる。
+//
+// スコープ:
+// - 本 fix の対象は `disconnect()` 内の `signalingSwitched === true` 経路かつ
+//   timeout サブ経路 (`DisconnectWaitTimeoutError`) に限定する。
+// - 他の 4999 サブ経路 (`DisconnectInternalError` / `DisconnectDataChannelError`) は
+//   本 fix の if/else 分岐自体は同じ経路を通るため、サブ経路を 1 つ踏めば回帰検知できる。
+//   onerror 発火を再現する fixture は AGENTS.md の「モック・スタブ禁止」と整合せず追加しない。
+// - 938 経路 (`!this.soraDataChannels.signaling`) は `signalingSwitched === false` 側のため
+//   本 fix の修正範囲外。
+// - normal 経路 (4999 ではない `code: 1000` / `reason: "TYPE-DISCONNECT"`) の確認は別 issue (0002)
+//   で `#disconnect-count` を含めて追加する想定のため本テストでは扱わない。
+// - 単体テスト (vitest) は `soraCloseEvent` が private のため追加できない。E2E のみで担保する。
+test("signaling switched 後の disconnect で timeout サブ経路を踏むと event type が abend になることを確認する", async ({
+  browser,
+}) => {
+  const page = await browser.newPage();
+
+  // disconnectWaitTimeout=0 にすると、`Promise.race` の timeout Promise が
+  // 次のマクロタスクで reject する。一方 DataChannel の正常 close は Sora との
+  // 往復 (最低 1 RTT) を要するため、実運用 RTT 下では timeout が安定して先勝ちする。
+  await page.goto("http://localhost:9000/data_channel_signaling_only/?disconnectWaitTimeout=0");
+
+  // バージョンチェック。本 fix のリグレッション検知を目的とするため、fix が入った
+  // SDK バージョン以降でのみテストを実行する。
+  const versionCheck = await checkSoraVersion(page, {
+    featureName: "disconnect abend on code 4999",
+    majorVersion: 2026,
+    minorVersion: 1,
+  });
+
+  test.skip(!versionCheck.isSupported, unsupportedVersionSkipReason(versionCheck.skipReason));
+
+  console.log(`sdkVersion=${versionCheck.version}`);
+
+  const channelName = randomUUID();
+  await page.fill("#channel-name", channelName);
+
+  await page.click("#connect");
+
+  // connection-id が設定されるまで待つ
+  await page.waitForSelector("#connection-id:not(:empty)");
+
+  const connectionId = await page.$eval("#connection-id", (el) => el.textContent);
+  console.log(`connectionId=${connectionId}`);
+
+  // switched コールバックが呼ばれて #switched-status が 'switched' になるまで待つ。
+  // switched 後は signaling DataChannel が存在するため、938 経路の
+  // "DISCONNECT-INTERNAL-ERROR" には入らないことが保証される。
+  await page.waitForSelector("#switched-status:not(:empty)");
+  const switchedStatus = await page.$eval("#switched-status", (el) => el.textContent);
+  expect(switchedStatus).toBe("switched");
+
+  await page.click("#disconnect");
+
+  // disconnect callback が呼ばれて event.type が abend になることを確認する。
+  // 修正前は無条件で normal に上書きされていたため、ここが abend になることが本 fix の本丸。
+  await expect(page.locator("#disconnect-event-type")).toHaveText("abend", { timeout: 5000 });
+
+  // 4999 のサブ経路を限定するため reason まで確認する。
+  // 938 経路の "DISCONNECT-INTERNAL-ERROR" や DC onerror 経路の
+  // "DISCONNECT-DATA-CHANNEL-ERROR" との誤検知を防ぐ。
+  // type / reason は同じ onDisconnect で同時に DOM 反映されるため、type が
+  // abend に到達した直後に reason も決まっている前提で短い timeout で十分。
+  await expect(page.locator("#disconnect-event-reason")).toHaveText(
+    "DISCONNECT-WAIT-TIMEOUT-ERROR",
+    { timeout: 1000 },
+  );
+
+  await page.close();
+});

--- a/issues/closed/0031-bug-fix-disconnect-event-overwrite-on-abend.md
+++ b/issues/closed/0031-bug-fix-disconnect-event-overwrite-on-abend.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-25
 - Polished: 2026-06-08
+- Completed: 2026-06-11
 - Model: Composer 2.5
 - Branch: feature/fix-disconnect-event-overwrite
 
@@ -118,3 +119,40 @@ if (result.code === 4999) {
   - [FIX] disconnect() で DataChannel 切断エラー (code 4999) 時に abend event が normal で上書きされないようにする
     - @voluntas
   ```
+
+## 解決方法
+
+### `src/base.ts` の修正
+
+`disconnect()` 内の `signalingSwitched === true` 経路 (`src/base.ts:1122-1146`) を以下のとおり修正した。
+
+- `result.code === 4999` のときは `event` を abend として通知する `if` 分岐に切り出し、normal による無条件上書きを停止した。`else` 分岐で従来どおり normal を生成する。
+- abend event には `soraCloseEvent` の第 3 引数 `initDict` 経由で `code` と `reason` を付与した。これによりアプリ側が `event.code` / `event.reason` から原因 (`DisconnectWaitTimeoutError` / `DisconnectInternalError` / `DisconnectDataChannelError`) を判別できる。
+- `title` (第 2 引数) には `result.reason` をそのまま渡す。本来 abend の `title` は `SoraAbendTitle` (`src/types.ts:498-505`) の体系だが、本 issue のスコープ外として `title` 統一は別 issue に委ねる。コメントでもその旨を明記している。
+- lint ルール `unicorn/prefer-ternary` は意図的に `eslint-disable-next-line` で抑止した。本 issue の設計方針 (`if/else` 分岐化) と、各分岐に対応する詳細コメントを残すため、ternary より `if/else` の方が読みやすい。
+
+### `e2e-tests/data_channel_signaling_only/` fixture の修正
+
+- `index.html` に `#disconnect-event-type` / `#disconnect-event-reason` の `div` を追加した (初期値は空)。
+- `main.ts` に以下を追加した。
+  - URL クエリ `?disconnectWaitTimeout=...` を読み取って `ConnectionOptions.disconnectWaitTimeout` に流し込む。`"0"` を falsy で握り潰さないため `=== null` で明示判定している (lint ルール `no-negated-condition` 回避を兼ねた書き方)。
+  - `SoraClient` の constructor に optional 引数 `disconnectWaitTimeout?: number` を追加し、constructor 内で `options` オブジェクトを組み立てるよう変更した。未指定時は SDK 既定値 (3000ms) に委ねる。
+  - `connection.on("disconnect", this.onDisconnect.bind(this))` で disconnect callback を登録する。`onDisconnect` は `event.type` / `event.reason` を DOM に出力する。後続 issue (0002) で disconnect 回数を数える処理を追加する際には、本 handler 内に処理を統合する旨をコメントで明示した (handler 二重登録禁止)。
+
+### `e2e-tests/tests/disconnect_event_type.test.ts` の追加
+
+`?disconnectWaitTimeout=0` を渡して `Promise.race` を timeout 側に確実に倒し、switched 後の `disconnect()` を呼ぶと `event.type === "abend"` かつ `event.reason === "DISCONNECT-WAIT-TIMEOUT-ERROR"` になることを確認する E2E テストを追加した。
+
+- バージョンチェックは本 fix のリグレッション検知を担保するため `majorVersion: 2026, minorVersion: 1` 以上で実行する。
+- 938 経路 (`!this.soraDataChannels.signaling`) は `signalingSwitched === false` 側に該当し本 fix の修正範囲外、DC `onerror` 経路は AGENTS.md「モック・スタブ禁止」と整合する形で fixture 化できないため、テストファイル冒頭コメントでスコープを明示した。
+- normal 経路 (4999 ではない `code: 1000` / `reason: "TYPE-DISCONNECT"`) の確認は別 issue (0002) で `#disconnect-count` を含めて追加する想定のため、本テストでは扱わない旨をコメントで明示した。
+- 単体テスト (vitest) は `soraCloseEvent` が `private` のため追加できない旨も併記した。
+
+### CHANGES.md の更新
+
+`## develop` セクションの `[FIX]` ブロックに以下を追記した。
+
+```
+- [FIX] disconnect() で DataChannel 切断エラー (code 4999) 時に abend event が normal で上書きされないようにする
+  - @voluntas
+```

--- a/src/base.ts
+++ b/src/base.ts
@@ -1122,11 +1122,20 @@ export default class ConnectionBase {
         let event = null;
         if (this.signalingSwitched) {
           const result = await this.disconnectDataChannel();
+          // code 4999 は DataChannel 切断処理の異常 (timeout / DC onerror / signaling DC 不在)
+          // を表す。abend として通知して normal 経路と区別する。
+          // initDict 経由で code / reason を付与し、アプリ側が原因を判定できるようにする。
+          // title (第 2 引数) には result.reason をそのまま渡す。本来 abend の title は
+          // SoraAbendTitle (src/types.ts:498-505) の体系だが、ここでの統一は本 issue のスコープ外。
+          // eslint-disable-next-line unicorn/prefer-ternary
           if (result.code === 4999) {
-            // DataChannel の切断処理がエラーの場合は event を abend に差し替える
-            event = this.soraCloseEvent("abend", result.reason);
+            event = this.soraCloseEvent("abend", result.reason, {
+              code: result.code,
+              reason: result.reason,
+            });
+          } else {
+            event = this.soraCloseEvent("normal", "DISCONNECT", result);
           }
-          event = this.soraCloseEvent("normal", "DISCONNECT", result);
           // もう切断されている可能性が高いが一応止める
           await this.disconnectWebSocket("NO-ERROR");
           this.maybeClosePeerConnection();


### PR DESCRIPTION
## 概要

`disconnect()` の `signalingSwitched === true` 経路で `disconnectDataChannel()` が `code === 4999` を返したとき、`event` を abend にセットした直後に無条件で `normal` で上書きしていた問題を修正する。DataChannel 切断エラーが normal disconnect としてアプリへ通知され、再接続判断やエラーハンドリングを誤らせるバグだった。

## 変更内容

- `src/base.ts`: `signalingSwitched === true` 経路で `result.code === 4999` のとき abend event を生成する `if/else` 分岐に切り替え、normal による無条件上書きを停止する。abend event には `initDict` 経由で `code` / `reason` を付与し、アプリ側が `event.code` / `event.reason` から原因 (timeout / internal error / DC onerror) を判別できるようにする。
- `e2e-tests/data_channel_signaling_only/index.html`: `#disconnect-event-type` / `#disconnect-event-reason` の DOM を追加する。
- `e2e-tests/data_channel_signaling_only/main.ts`: URL クエリ `?disconnectWaitTimeout=...` を読み取って `ConnectionOptions.disconnectWaitTimeout` に流し込む。`"0"` を falsy で握り潰さないよう `=== null` で明示判定する。`onDisconnect` handler で `event.type` / `event.reason` を DOM に出力する。
- `e2e-tests/tests/disconnect_event_type.test.ts`: switched 後の `disconnect()` で timeout サブ経路 (`disconnectWaitTimeout=0` で `Promise.race` を timeout 側に倒す) を踏むと `event.type === "abend"` かつ `event.reason === "DISCONNECT-WAIT-TIMEOUT-ERROR"` になることを確認する E2E テストを新規追加する。
- `CHANGES.md`: `## develop` の `[FIX]` ブロックに 1 件追記する。

## 完了条件

- [x] `code === 4999` のとき normal で上書きしない (`else` 分岐化)
- [x] abend event に `code` / `reason` が `initDict` 経由で入る
- [x] `e2e-tests/data_channel_signaling_only/index.html` に `#disconnect-event-type` / `#disconnect-event-reason` を追加する
- [x] `main.ts` で disconnect event の type / reason を DOM に出し、`disconnectWaitTimeout` をクエリから設定可能にする (`"0"` を falsy で握り潰さず `!== null` で判定)
- [x] 新規 E2E で timeout 経路 (4999) 限定で event type が `abend`、reason が `"DISCONNECT-WAIT-TIMEOUT-ERROR"` であることを assert する
- [x] ローカルで `pnpm test` および `pnpm e2e-test --grep "signaling switched"` が通ること
- [x] `CHANGES.md` の `## develop` に `[FIX]` エントリを追記する

## 関連 issue

- `issues/closed/0031-bug-fix-disconnect-event-overwrite-on-abend.md`

## 補足

- レビューで挙がった `soraCloseEvent` constructor の truthy 判定 (`if (initDict.code)` / `if (initDict.reason)`) による `code === 0` や空 `reason` の握り潰しは既存挙動。本 PR では `code === 4999` / 非空 `reason` のみを渡すため実害なし。将来的な API 拡張時に顕在化するため、別途 issue 化を推奨する。
- abend event の `title` は本 issue ではスコープ外として `result.reason` を維持する。`SoraAbendTitle` 体系への統一は別 issue で扱う。
- normal 経路の E2E テストは別 issue (0002) で `#disconnect-count` と合わせて追加する想定のため本 PR では含めない。
- DC `onerror` 経路 / 938 経路 (`!this.soraDataChannels.signaling`) の E2E は、AGENTS.md「モック・スタブ禁止」と整合する形での fixture 化が難しいため対象外。本 fix の `if/else` 分岐自体は同じ経路を通るため、timeout サブ経路 1 つで回帰検知できる。