### PR TITLE
createSignalingMessage で undefined 値が message に積まれる経路を塞ぐ

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,9 @@
   - @voluntas
 - [FIX] disconnect() で DataChannel 切断エラー (code 4999) 時に abend event が normal で上書きされないようにする
   - @voluntas
+- [FIX] createSignalingMessage で `{ audioBitRate: undefined }` のような呼び出しで message.audio / message.video が boolean true から空オブジェクト {} に置換されていたのを修正する
+  - 関連して spotlightNumber / audioOpusParams\* に undefined を渡しても message に undefined キーが積まれないようにする
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0018-bug-fix-in-operator-picks-undefined-values.md
+++ b/issues/closed/0018-bug-fix-in-operator-picks-undefined-values.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-11
+- Completed: 2026-06-12
 - Model: Opus 4.7
 - Branch: feature/fix-undefined-options-in-create-signaling-message
 
@@ -122,3 +123,20 @@ test("createSignalingMessage audioBitRate: 100, audioCodecType: undefined", () =
 - `tests/utils.test.ts` に「3-2」のケース表 4 件を新規追加する
 - ローカルで `pnpm test` / `pnpm typecheck` / `pnpm lint` が pass し、`pnpm fmt` で差分が出ないこと
 - `CHANGES.md` `## develop` 本体に `[FIX]` エントリ 1 件を追記する
+
+## 解決方法
+
+設計方針 1 / 2 / 3 / 4 をすべて反映した。
+
+- `src/utils.ts:168-170`: `"spotlightNumber" in options` を `typeof options.spotlightNumber === "number"` に変更。`spotlightNumber: undefined` で `message.spotlight_number = undefined` が積まれる経路を塞いだ
+- `src/utils.ts:238-260`: 3 つの `continue` 条件の `copyOptions[key] !== null` を `copyOptions[key] !== null && copyOptions[key] !== undefined` に変更
+  - 設計方針 2 は `copyOptions[key] != null` (loose equality) を提案していたが、リポジトリの lint 設定 `vite.config.ts:162` が `eqeqeq: "error"` を有効にしており `!=` / `==` を許容しないため、動作上等価な `!== null && !== undefined` (strict equality の AND) を採用した
+  - `undefined != null` ⇔ `!(undefined !== null && undefined !== undefined)` ⇔ false で挙動完全一致
+- `tests/utils.test.ts:807-819` (旧位置): 期待値を `baseExpectedMessage` に書き換え、コメントを `typeof === "number"` ガード根拠に更新
+- `tests/utils.test.ts`: 新規回帰テスト 4 件を追加
+  - `createSignalingMessage audioBitRate: undefined` (audio parameters テスト直後)
+  - `createSignalingMessage audioBitRate: 100, audioCodecType: undefined` (ケース 1 直後、混在ケース)
+  - `createSignalingMessage audioOpusParamsChannels: undefined` (audioOpusParamsUsedtx テスト直後、opus_params 群末尾)
+  - `createSignalingMessage videoBitRate: undefined` (video parameters テスト直後)
+- ローカル検証: `pnpm test` (82 件 pass) / `pnpm typecheck` / `pnpm lint` / `pnpm fmt` すべて pass・差分なし
+- `CHANGES.md` `## develop` 本体の `[FIX]` 群末尾に `[FIX]` エントリ 1 件を追記

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -165,7 +165,7 @@ export function createSignalingMessage(
   if (typeof options.spotlight === "boolean") {
     message.spotlight = options.spotlight;
   }
-  if ("spotlightNumber" in options) {
+  if (typeof options.spotlightNumber === "number") {
     message.spotlight_number = options.spotlightNumber;
   }
   const spotlightFocusRids = ["none", "r0", "r1", "r2"];
@@ -235,13 +235,27 @@ export function createSignalingMessage(
     if (key === "video" && typeof copyOptions[key] === "boolean") {
       continue;
     }
-    if (audioPropertyKeys.includes(key) && copyOptions[key] !== null) {
+    // null だけでなく undefined も delete 側に流すために両方を明示的に弾く
+    // (`!== null` 単独だと `undefined !== null` が真になり `undefined` キーが残ってしまうため)
+    if (
+      audioPropertyKeys.includes(key) &&
+      copyOptions[key] !== null &&
+      copyOptions[key] !== undefined
+    ) {
       continue;
     }
-    if (audioOpusParamsPropertyKeys.includes(key) && copyOptions[key] !== null) {
+    if (
+      audioOpusParamsPropertyKeys.includes(key) &&
+      copyOptions[key] !== null &&
+      copyOptions[key] !== undefined
+    ) {
       continue;
     }
-    if (videoPropertyKeys.includes(key) && copyOptions[key] !== null) {
+    if (
+      videoPropertyKeys.includes(key) &&
+      copyOptions[key] !== null &&
+      copyOptions[key] !== undefined
+    ) {
       continue;
     }
     delete copyOptions[key];

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -184,6 +184,30 @@ test("createSignalingMessage audio parameters", () => {
   ).toStrictEqual(expectedMessage);
 });
 
+test("createSignalingMessage audioBitRate: undefined", () => {
+  // audioBitRate: undefined 単独の場合、copyOptions delete ループで undefined キーが除去されるため
+  // hasAudioProperty が false のまま message.audio は boolean true を保つ
+  const options = {
+    audioBitRate: undefined,
+  };
+  expect(
+    createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
+  ).toStrictEqual(baseExpectedMessage);
+});
+
+test("createSignalingMessage audioBitRate: 100, audioCodecType: undefined", () => {
+  // 有効値 audioBitRate: 100 のみが拾われ、undefined の audioCodecType は delete ループで除外される
+  // (修正前は codec_type: undefined キーも message.audio に残り audio: { codec_type: undefined, bit_rate: 100 } となるため toStrictEqual で fail する)
+  const options = {
+    audioBitRate: 100,
+    audioCodecType: undefined,
+  };
+  const expectedMessage = { ...baseExpectedMessage, audio: { bit_rate: 100 } };
+  expect(
+    createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
+  ).toStrictEqual(expectedMessage);
+});
+
 test("createSignalingMessage audioOpusParamsChannels", () => {
   const options = {
     audioOpusParamsChannels: 2,
@@ -320,6 +344,17 @@ test("createSignalingMessage audioOpusParamsUsedtx", () => {
   ).toStrictEqual(expectedMessage);
 });
 
+test("createSignalingMessage audioOpusParamsChannels: undefined", () => {
+  // audioOpusParamsChannels: undefined 単独の場合、copyOptions delete ループで undefined キーが
+  // 除去されるため hasAudioOpusParamsProperty が false のまま opus_params の {} 化は発生しない
+  const options = {
+    audioOpusParamsChannels: undefined,
+  };
+  expect(
+    createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
+  ).toStrictEqual(baseExpectedMessage);
+});
+
 /**
  * video test
  */
@@ -370,6 +405,17 @@ test("createSignalingMessage video parameters", () => {
   expect(
     createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
   ).toStrictEqual(expectedMessage);
+});
+
+test("createSignalingMessage videoBitRate: undefined", () => {
+  // videoBitRate: undefined 単独の場合、copyOptions delete ループで undefined キーが除去されるため
+  // hasVideoProperty が false のまま message.video は boolean true を保つ
+  const options = {
+    videoBitRate: undefined,
+  };
+  expect(
+    createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
+  ).toStrictEqual(baseExpectedMessage);
 });
 
 /**
@@ -808,14 +854,11 @@ test("createSignalingMessage spotlightNumber: undefined", () => {
   const options = {
     spotlightNumber: undefined,
   };
-  // spotlightNumber が options に含まれる場合は undefined でも spotlight_number が設定される
-  const expectedMessage = {
-    ...baseExpectedMessage,
-    spotlight_number: undefined,
-  };
+  // spotlightNumber: undefined は typeof options.spotlightNumber === "number" ガードで弾かれ
+  // message.spotlight_number キー自体が積まれない
   expect(
     createSignalingMessage(sdp, "sendonly", channelId, undefined, options, false),
-  ).toStrictEqual(expectedMessage);
+  ).toStrictEqual(baseExpectedMessage);
 });
 
 test("createSignalingMessage audioStreamingLanguageCode: undefined", () => {


### PR DESCRIPTION
## 概要

`createSignalingMessage` (`src/utils.ts`) が `\"X\" in options` / `\"X\" in copyOptions` と `!== null` 判定により `undefined` 値を持つ options キーを拾って message に積んでしまう問題を修正する。特に audio / video パラメータ経路では `message.audio` が boolean true から空オブジェクト `{}` に置換される実害があった。

## 変更内容

- `src/utils.ts:168-170`: `\"spotlightNumber\" in options` を `typeof options.spotlightNumber === \"number\"` に変更し、`message.spotlight_number = undefined` の代入を防ぐ
- `src/utils.ts:238-260`: 3 つの `continue` 条件の `copyOptions[key] !== null` を `copyOptions[key] !== null && copyOptions[key] !== undefined` に変更し、`undefined` キーを delete 側に流す
  - issue の設計方針は `copyOptions[key] != null` (loose equality) を提案していたが、`vite.config.ts` の `eqeqeq: \"error\"` 制約のため動作等価な strict equality の AND 形式を採用
- `tests/utils.test.ts`: 既存の `spotlightNumber: undefined` テストの期待値を `baseExpectedMessage` に書き換え、新規回帰テスト 4 件を追加
- `CHANGES.md` の `## develop` 本体に `[FIX]` エントリ 1 件を追記

## 完了条件

- [x] `src/utils.ts:168-170` の `spotlightNumber` ガードを `typeof options.spotlightNumber === \"number\"` に変える
- [x] `src/utils.ts:238-246` の 3 つの `continue` 条件を `copyOptions[key] != null` 相当 (動作等価な strict 形式) に変える
- [x] 既存 `tests/utils.test.ts` の `spotlightNumber: undefined` テストの期待値を `baseExpectedMessage` に書き換える
- [x] `tests/utils.test.ts` に 4 件 (audioBitRate / audioOpusParamsChannels / videoBitRate / audioBitRate+audioCodecType 混在) を新規追加する
- [x] ローカルで `pnpm test` / `pnpm typecheck` / `pnpm lint` が pass し、`pnpm fmt` で差分が出ないこと
- [x] `CHANGES.md` `## develop` 本体に `[FIX]` エントリ 1 件を追記する

## 関連 issue

- issues/closed/0018-bug-fix-in-operator-picks-undefined-values.md