### PR TITLE
0020 trace() が JWT / metadata を console に無サニタイズで出力するセキュリティ問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,8 @@
 - [FIX] ConnectionBase constructor で options を shallow copy し skipIceCandidateEvent の内部代入が呼び出し側 options に漏れないように修正する
   - 上記 messaging() の修正とあわせて、同一 options を sendrecv() / sendonly() / recvonly() と messaging() に渡したときに先行 Connection の options まで書き換わる問題も解消する
   - @voluntas
+- [FIX] trace() が JWT 等の機密を含む metadata を console / callbacks.log に raw 出力していたセキュリティ問題を redact で修正する
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0020-bug-fix-trace-leaks-jwt-and-metadata.md
+++ b/issues/closed/0020-bug-fix-trace-leaks-jwt-and-metadata.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-21
+- Completed: 2026-06-12
 - Polished: 2026-06-08
 - Model: Opus 4.7
 - Branch: feature/fix-trace-redact-secrets
@@ -143,3 +144,19 @@ test("redact は非対象キーをそのまま残す", () => {
 - `tests/utils.test.ts` に redact 単体テスト 3 件を追加する
 - ローカルで `pnpm test` が通ること
 - CHANGES.md `## develop` にセキュリティ修正 `[FIX]` エントリを追記する
+
+## 解決方法
+
+- `src/utils.ts` に `redact` 関数 (公開 export、`@internal`) と再帰実装 `redactInner` を追加した
+  - `REDACT_KEYS` の集合 (`metadata` / `signaling_notify_metadata` / `authn_metadata` / `authz_metadata` / `access_token` / `secret`) にキー名完全一致する値を `[REDACTED]` 文字列で置換する
+  - プリミティブ・null・undefined・文字列 (SDP など) は早期 return で素通り (SDP redact は本 issue のスコープ外)
+  - `Object.getPrototypeOf` で plain object 判定し、`Date` / `RTCCertificate` / `RTCIceCandidate` 等のクラスインスタンスは `Object.entries` で getter ベースのプロパティが拾えず空オブジェクトに潰れるため bypass する
+  - `WeakSet` で循環参照を検出し、再訪時は `[Circular]` 文字列に置換してスタックオーバーフローを防ぐ
+- `src/utils.ts` の `trace` 関数で `dump` に渡す前に `redact` を適用した
+- `src/base.ts` の `ConnectionBase.trace` で `callbacks.log` および `utils.trace` の両経路に redact 済みの値を渡すように変更した。`utils` からの import に `redact` を追加した
+- `tests/utils.test.ts` に redact の単体テストを追加した
+  - issue 設計方針通りの基本 3 件 (機密キー置換 / ネスト・配列の再帰 / 非対象キーの保持)
+  - REDACT_KEYS 全 6 キーの網羅 (`test.each`)
+  - プリミティブ・null・undefined・文字列・数値・真偽値の境界値 (`test.each`)
+  - 配列ルートの再帰、3 段以上のネスト、非破壊性、クラスインスタンス bypass、循環参照、DAG 兄弟参照の挙動固定化
+- `CHANGES.md` の `## develop` セクションに `[FIX]` エントリを追加した

--- a/src/base.ts
+++ b/src/base.ts
@@ -74,6 +74,7 @@ import {
   isFirefox,
   isSafari,
   parseDataChannelEventData,
+  redact,
   trace,
 } from "./utils";
 
@@ -1901,15 +1902,21 @@ export default class ConnectionBase {
   /**
    * trace log を出力するメソッド
    *
+   * @remarks
+   * `callbacks.log` (debug 無関係で常に呼ばれる) と console 出力 (utils.trace、
+   * `this.debug === true` 時のみ) の両経路に同じ redact 済み参照を渡すことで、
+   * JWT 等の機密情報を含む `metadata` 等のキーが平文露出しないように一括で塞ぐ
+   *
    * @param title - ログのタイトル
    * @param message - ログの本文
    */
   protected trace(title: string, message: unknown): void {
-    this.callbacks.log(title, message as JSONType);
+    const redacted = redact(message) as JSONType;
+    this.callbacks.log(title, redacted);
     if (!this.debug) {
       return;
     }
-    trace(this.clientId, title, message);
+    trace(this.clientId, title, redacted);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,7 +376,110 @@ export function getSignalingNotifyData(
   return [];
 }
 
+// trace ログ出力時に値を [REDACTED] に置換するキー名の集合
+//
+// metadata / signaling_notify_metadata / authn_metadata / authz_metadata は
+// Sora シグナリングメッセージ・notify メッセージで JWT 等の機密情報を運ぶ
+// 実フィールドのため、必ず redact する
+//
+// access_token / secret は Sora のシグナリングメッセージのトップレベルには
+// 通常現れないが、利用者が指定する metadata の内部 (例: { metadata: { access_token } })
+// や非 metadata キー配下に機密が現れた場合に再帰で捕捉するための defensive な
+// キーとして含める
+//
+// 注意: REDACT_KEYS は types.ts の型定義と自動連動しない。機密キーが types.ts に
+// 追加された場合は手動でここに追加すること
+const REDACT_KEYS = new Set([
+  "metadata",
+  "signaling_notify_metadata",
+  "authn_metadata",
+  "authz_metadata",
+  "access_token",
+  "secret",
+]);
+
+/**
+ * trace ログ出力時に機密キーの値を `[REDACTED]` に置換する
+ *
+ * @remarks
+ * 入力は JSON サブセット (JSONType) を想定する。trace 経路に渡る値は signaling
+ * メッセージ等の plain object / 配列 / プリミティブが大半。
+ *
+ * 挙動:
+ *
+ * - キー名の完全一致のみで判定する。値の中身を走査して JWT 文字列を検出する処理はしない
+ * - 入力オブジェクトを mutation せず、plain object / 配列の場合は新しい値を返す
+ *   (非破壊)。プリミティブ・クラスインスタンスは同じ参照/値を返す
+ * - ネストしたオブジェクト・配列も再帰的に処理する
+ * - プリミティブ値・null・undefined はそのまま返す
+ * - 文字列 (例: `OFFER SDP` で渡される SDP 文字列) は早期 return 経路を通過するため
+ *   redact 対象外 (issue 0020 設計方針より SDP は redact しない)
+ * - `bigint` / `symbol` / `function` は JSONType の範囲外だが、早期 return 経路で
+ *   そのまま素通りする。trace の呼び出し元はこれらを渡さない前提
+ * - `Date` / `RegExp` / `RTCCertificate` / `RTCIceCandidate` 等の plain object
+ *   ではないクラスインスタンスはそのまま返す。これらは `Object.entries` で
+ *   getter ベースのプロパティが拾えず空オブジェクトに潰れてしまうため、
+ *   `Object.getPrototypeOf` で plain object 判定して bypass する。前提として
+ *   現状の trace 呼び出しサイトではクラスインスタンスの中に機密キーは含まれない
+ *   (`RTCCertificate` / `RTCIceCandidate` 等のブラウザネイティブオブジェクトは
+ *   metadata 等の機密フィールドを持たない)
+ * - `Object.create(null)` 由来の prototype が `null` のオブジェクトは plain object
+ *   と同等に redact 対象として扱う
+ * - 循環参照を持つオブジェクトは `WeakSet` で検出し、再訪時は `"[Circular]"`
+ *   文字列に置換することでスタックオーバーフローを防ぐ。`WeakSet` は再帰ツリー
+ *   全体で共有されるため、DAG 構造 (同一オブジェクトを複数箇所から参照) でも
+ *   後から訪れた参照は `"[Circular]"` に置換される。trace 経路に渡る値は signaling
+ *   メッセージ等の tree 構造のみで、DAG は通常発生しない
+ *
+ * 利用範囲: trace 経路 (`utils.trace` / `ConnectionBase.trace`) 専用の内部ヘルパ。
+ * SDK 利用者向けの公開 API ではない。
+ *
+ * @internal
+ * @param value - redact 対象の値
+ * @returns 機密キーの値が `[REDACTED]` に置換された値
+ */
+export function redact(value: unknown): unknown {
+  return redactInner(value, new WeakSet());
+}
+
+/**
+ * `redact` の再帰実装本体。訪問済みオブジェクト集合 `seen` を伝播させて
+ * 循環参照を検出する
+ */
+function redactInner(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  // 循環参照を検出したら `[Circular]` 文字列に置換してスタックオーバーフローを防ぐ
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  if (Array.isArray(value)) {
+    seen.add(value);
+    // map に redactInner を直接渡すと余分な引数 (index / 配列) が seen 引数として
+    // 渡ってしまうため、第一引数のみを受ける arrow 関数でラップする
+    return value.map((v) => redactInner(v, seen));
+  }
+  // plain object 以外 (Date / RTCCertificate / RTCIceCandidate 等のクラスインスタンス)
+  // は Object.entries で enumerable own data properties しか拾えず、getter ベースの
+  // プロパティが失われて空オブジェクトに潰れてしまう。trace 経路で機密情報を含まない
+  // ことが明らかなため、そのまま値を返す
+  // (Object.getPrototypeOf の戻り値型は lib.es5 で any のため、明示的に object | null
+  //  に絞る)
+  const proto = Object.getPrototypeOf(value) as object | null;
+  if (proto !== null && proto !== Object.prototype) {
+    return value;
+  }
+  seen.add(value);
+  const result: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = REDACT_KEYS.has(key) ? "[REDACTED]" : redactInner(v, seen);
+  }
+  return result;
+}
+
 export function trace(clientId: string | null, title: string, value: unknown): void {
+  const redactedValue = redact(value);
   const dump = (record: unknown): void => {
     if (record && typeof record === "object") {
       let keys = null;
@@ -416,12 +519,12 @@ export function trace(clientId: string | null, title: string, value: unknown): v
   if (console.info !== undefined && console.group !== undefined) {
     // eslint-disable-next-line no-console
     console.group(`${prefix} ${title}`);
-    dump(value);
+    dump(redactedValue);
     // eslint-disable-next-line no-console
     console.groupEnd();
   } else {
     // eslint-disable-next-line no-console
-    console.log("%s %s\n", prefix, title, value);
+    console.log("%s %s\n", prefix, title, redactedValue);
   }
 }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,7 +1,7 @@
 // XXX: assert を使うと型がエラーがうるさいため expect を使ってる
 
 import type { AudioCodecType, DataChannelDirection, VideoCodecType } from "../src/types";
-import { ConnectError, createSignalingMessage } from "../src/utils";
+import { ConnectError, createSignalingMessage, redact } from "../src/utils";
 
 const channelId = "7N3fsMHob";
 const metadata = "PG9A6RXgYqiqWKOVO";
@@ -931,3 +931,119 @@ test.each([["WS_SEND_INVALID_STATE"], ["WS_SEND_FAILED"]])(
     expect(e.reason).toBe(reason);
   },
 );
+
+/**
+ * redact のテスト
+ *
+ * trace 経路で JWT 等の機密情報が console / callbacks.log に raw 出力される
+ * セキュリティ問題 (issue 0020) を塞ぐ redact 関数を検証する
+ */
+
+// トップレベルの機密キー (metadata) は値の中身を見ずに `[REDACTED]` に置換される
+// 非機密キー (sdp) はそのまま残る
+test("redact は機密キーを [REDACTED] に置換する", () => {
+  expect(redact({ metadata: { access_token: "jwt" }, sdp: "v=0" })).toStrictEqual({
+    metadata: "[REDACTED]",
+    sdp: "v=0",
+  });
+});
+
+// 配列内のオブジェクトでも機密キー (authn_metadata) が再帰的に redact される
+// 非対象キー (type) は影響を受けない
+test("redact はネストと配列を再帰処理する", () => {
+  expect(redact({ items: [{ authn_metadata: "secret" }, { type: "ok" }] })).toStrictEqual({
+    items: [{ authn_metadata: "[REDACTED]" }, { type: "ok" }],
+  });
+});
+
+// 機密キーを含まないオブジェクトは値も構造もそのまま残る
+test("redact は非対象キーをそのまま残す", () => {
+  expect(redact({ channel_id: "ch", role: "sendrecv" })).toStrictEqual({
+    channel_id: "ch",
+    role: "sendrecv",
+  });
+});
+
+// REDACT_KEYS の全 6 キーが個別に redact 対象であることを固定化する
+// (将来 REDACT_KEYS から 1 つでも漏れたら該当ケースが fail する)
+test.each([
+  ["metadata"],
+  ["signaling_notify_metadata"],
+  ["authn_metadata"],
+  ["authz_metadata"],
+  ["access_token"],
+  ["secret"],
+])("redact は %s キーを [REDACTED] に置換する", (key) => {
+  expect(redact({ [key]: "sensitive" })).toStrictEqual({ [key]: "[REDACTED]" });
+});
+
+// プリミティブ・null・undefined はそのまま返る (再帰の早期 return 経路)
+// ConnectionBase.trace の message: unknown は任意の型で渡りうるため境界値を保証する
+test.each([
+  ["null", null, null],
+  ["undefined", undefined, undefined],
+  ["文字列", "hello", "hello"],
+  ["数値", 42, 42],
+  ["真偽値", true, true],
+])("redact は非 object 値 (%s) をそのまま返す", (_label, input, expected) => {
+  expect(redact(input)).toBe(expected);
+});
+
+// 配列ルート (トップが配列) でも各要素が再帰的に redact される
+test("redact は配列ルートを再帰処理する", () => {
+  expect(redact([{ metadata: "x" }, { sdp: "v=0" }])).toStrictEqual([
+    { metadata: "[REDACTED]" },
+    { sdp: "v=0" },
+  ]);
+});
+
+// 多段ネスト (3 段以上) でも機密キーが再帰的に redact される
+test("redact は 3 段以上のネストでも機密キーを redact する", () => {
+  expect(redact({ a: { b: { metadata: "jwt", sdp: "v=0" } } })).toStrictEqual({
+    a: { b: { metadata: "[REDACTED]", sdp: "v=0" } },
+  });
+});
+
+// redact は入力を mutation せず新しいオブジェクトを返す (非破壊契約の固定化)
+// trace 呼び出し元では redact 後も signaling メッセージ送信を続けるため、in-place
+// 化は危険。回帰防止のために明示的なテストを置く
+test("redact は元のオブジェクトを破壊せず新しい値を返す", () => {
+  const original = { metadata: { jwt: "x" }, sdp: "v=0" };
+  const snapshot = JSON.stringify(original);
+  const result = redact(original);
+  expect(JSON.stringify(original)).toBe(snapshot);
+  expect(result).not.toBe(original);
+});
+
+// plain object ではないクラスインスタンス (例: Date) は Object.entries で
+// 内部状態が拾えず空オブジェクトに潰れてしまうため、そのまま返す
+// (PEER CONNECTION CONFIG の RTCCertificate / ONICECANDIDATE の RTCIceCandidate
+// などのデバッグ情報が消えないようにするための bypass)
+test("redact はクラスインスタンスを bypass してそのまま返す", () => {
+  const date = new Date(0);
+  expect(redact(date)).toBe(date);
+});
+
+// 循環参照を含むオブジェクトを渡してもスタックオーバーフローせず、再訪箇所は
+// `[Circular]` 文字列に置換される。入力オブジェクト側の循環参照は破壊せず維持する
+test("redact は循環参照を `[Circular]` に置換する", () => {
+  const obj: Record<string, unknown> = { name: "root" };
+  obj.self = obj;
+  const result = redact(obj) as Record<string, unknown>;
+  expect(result.name).toBe("root");
+  expect(result.self).toBe("[Circular]");
+  expect(result).not.toBe(obj);
+  // 入力オブジェクト側の循環参照はそのまま残っていること (非破壊)
+  expect(obj.self).toBe(obj);
+});
+
+// DAG 構造 (同一オブジェクトを複数箇所から参照) の挙動を固定化する
+// trace 経路に渡る signaling メッセージは tree 構造で DAG は通常発生しないが、
+// WeakSet を再帰ツリー全体で共有しているため、後から訪れた参照は `[Circular]`
+// に置換される挙動である
+test("redact は DAG の兄弟参照を `[Circular]` 化する", () => {
+  const sub = { x: 1 };
+  const result = redact({ a: sub, b: sub }) as Record<string, unknown>;
+  expect(result.a).toStrictEqual({ x: 1 });
+  expect(result.b).toBe("[Circular]");
+});


### PR DESCRIPTION
## 概要

`trace()` (`src/utils.ts`) と `ConnectionBase.trace` (`src/base.ts`) が signaling message を raw のまま `console` および `callbacks.log` に出力していたため、`debug: true` 環境で DevTools Console から JWT 等の機密情報が平文で読み取れるセキュリティ問題を redact 関数で修正する。

`ConnectionBase.trace` は `callbacks.log` を `this.debug` に関わらず常に呼ぶため、`debug: false` 環境でも `callbacks.log` を登録しているアプリで raw が外部へ渡る経路も同時に塞ぐ。

## 変更内容

- `src/utils.ts` に `redact` 関数 (`@internal`) と再帰実装 `redactInner` を追加
  - `REDACT_KEYS` (`metadata` / `signaling_notify_metadata` / `authn_metadata` / `authz_metadata` / `access_token` / `secret`) にキー名完全一致する値を `[REDACTED]` 文字列で置換
  - プリミティブ・null・undefined・文字列 (SDP など) は早期 return で素通り (SDP の redact は本 issue のスコープ外)
  - `Object.getPrototypeOf` で plain object 判定し、`Date` / `RTCCertificate` / `RTCIceCandidate` 等のクラスインスタンスは `Object.entries` で getter ベースのプロパティが拾えず空オブジェクトに潰れるため bypass する
  - `WeakSet` で循環参照を検出し、再訪時は `[Circular]` 文字列に置換してスタックオーバーフローを防ぐ
- `src/utils.ts` の `trace` 関数で `dump` に渡す前に `redact` を適用
- `src/base.ts` の `ConnectionBase.trace` で `callbacks.log` および `utils.trace` の両経路に redact 済みの値を渡すよう変更
- `tests/utils.test.ts` に redact の単体テストを追加 (基本 3 件 + 6 キー網羅 / 境界値 / 非破壊性 / クラスインスタンス bypass / 循環参照 / DAG 兄弟参照)
- `CHANGES.md` の `## develop` に `[FIX]` エントリを追加

## 残存リスク (リリース時の注意)

本修正で塞がるのは trace 経路 (`callbacks.log` / `debug: true` 時の console) のみ。同じ機密メッセージは trace を経由しない `writeWebSocketSignalingLog` → `callbacks.signaling` / `callbacks.timeline` 経路では raw のまま渡されるため、これらを登録しているアプリでは引き続き機密が露出する可能性がある (別途フォローアップ issue で対応予定)。

## 後方互換

`callbacks.log` に渡る値が raw → redacted へ変わる挙動変更だが、機密漏洩を塞ぐ目的なので `[FIX]` として妥当。

## 完了条件

- [x] `redact` を実装し `utils.trace` / `ConnectionBase.trace` の両方で使用する
- [x] `tests/utils.test.ts` に redact 単体テスト 3 件を追加する (実際は 13 件超のケースをカバー)
- [x] ローカルで `pnpm test` が通ること (105 件 pass)
- [x] CHANGES.md `## develop` にセキュリティ修正 `[FIX]` エントリを追記する

## 関連 issue

- issues/closed/0020-bug-fix-trace-leaks-jwt-and-metadata.md