### PR TITLE
0024 npm-publish.yml のタグトリガが緩くタグと package.json の不整合で誤 publish される問題を修正する

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,16 +3,39 @@ name: npm-publish
 on:
   push:
     tags:
-      - "*"
+      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*"
+      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-canary.[0-9]*"
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
+  verify-version:
+    name: Verify tag matches package.json version
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Compare tag name with package.json version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$TAG_NAME" ]; then
+            echo "::error::Tag ${TAG_NAME} does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "Tag ${TAG_NAME} matches package.json version ${PKG_VERSION}"
+
   build:
     name: Build
     runs-on: ubuntu-slim
+    needs: [verify-version]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -34,7 +57,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ contains(github.ref, 'canary') }}
+    if: ${{ contains(github.ref_name, '-canary.') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -60,7 +83,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !contains(github.ref, 'canary') }}
+    if: ${{ !contains(github.ref_name, '-canary.') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,8 @@
   - @voluntas
 - [FIX] macOS の Google Chrome stable インストールが 302 リダイレクトを追従できず失敗するため playwright-core にパッチを当てて `curl` に `-L` を追加する
   - @voluntas
+- [FIX] npm-publish workflow のタグトリガを厳格化し、タグ名と package.json の version が一致しない場合は publish 前に fail させる
+  - @voluntas
 
 ## 2025.2.0
 

--- a/issues/closed/0024-ci-fix-npm-publish-tag-version-mismatch.md
+++ b/issues/closed/0024-ci-fix-npm-publish-tag-version-mismatch.md
@@ -2,6 +2,7 @@
 
 - Priority: High
 - Created: 2026-05-21
+- Completed: 2026-06-12
 - Polished: 2026-06-12
 - Model: Opus 4.7
 - Branch: feature/fix-npm-publish-tag-version-mismatch
@@ -219,3 +220,16 @@ glob で `-canary.` を含むタグは canary 命名規約 (`<version>-canary.<n
 ## マージ順
 
 `0024 → 0026 → 0033` を推奨する。0024 と 0026 はいずれも `npm-publish.yml` を編集するが編集箇所は競合しない (0024 は `on.push.tags` / publish ジョブの `if` / 新規 `verify-version` ジョブ + `build` への `needs:` 追加、0026 はトップレベル `permissions:` の `id-token: write` 1 行削除 + e2e 系 5 workflow への `permissions: contents: read` 追加)。0024 のほうが workflow 構造変更が大きく後続 PR の差分が読みやすくなるため、`0024 → 0026` の順を推奨する。
+
+## 解決方法
+
+`.github/workflows/npm-publish.yml` に対して以下 4 点を反映した。
+
+1. `on.push.tags` を `"*"` から CalVer 系 2 つの厳格 glob (`[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*` と `[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-canary.[0-9]*`) に変更し、4 桁年で始まる CalVer 以外のタグでは workflow が発火しないようにした
+2. `jobs:` 直下 (`build:` の直前) に `verify-version` ジョブを新設した。`permissions: contents: read` のみを明示してトップレベル `permissions:` (`id-token: write` / `contents: read`) の継承を断ち、`actions/checkout` と `actions/setup-node@v6.4.0` (node 22) を経由して、step 単位の `env:` 経由で受けた `TAG_NAME` (`github.ref_name`) と `node -p "require('./package.json').version"` の結果を比較する。一致しない場合は `::error::` を出して `exit 1` する
+3. `build` ジョブの `runs-on: ubuntu-slim` の直後に `needs: [verify-version]` を追加した。`verify-version` が fail / cancel / skipped になった場合は `build` も skip され、後続の `npm-publish-canary` / `npm-publish` も skip される間接ガード経路が成立する (`build` の `if:` は付けない)
+4. `npm-publish-canary` と `npm-publish` の `if:` を `contains(github.ref, 'canary')` から `contains(github.ref_name, '-canary.')` / `!contains(github.ref_name, '-canary.')` に変更した。`-canary.` を末尾区切り込みで判定することで `-canaryfoo` のような誤判定を排除する
+
+既存の publish step (`npm install -g npm@latest` / `npm publish --no-git-checks` / `npm publish --no-git-checks --tag canary`) と `slack_notify` ジョブは無編集のまま維持した。
+
+検証はリポジトリ内で bash の `case` 文による glob 挙動の補助確認と、`verify-version` スクリプトの一致 (`TAG_NAME=2026.1.0-canary.1` で exit 0)・不一致 (`TAG_NAME=2025.2.0` で `::error::` + exit 1) 経路をローカル実行で確認した。tag push による実機 publish 経路の検証は誤 publish のリスクがあるため行っていない (issue 完了条件で許容)。


### PR DESCRIPTION
## 概要

`.github/workflows/npm-publish.yml` のタグトリガ (`tags: "*"`) を厳格化し、タグ名と `package.json` の `version` が一致しない場合は publish 前に fail させる。npm publish は不可逆 (同名 version 再 push 不可、72 時間以降の unpublish 不可) のため、構造的なガードを workflow に追加する。

## 変更内容

- `on.push.tags` を CalVer 系 2 つの厳格 glob (`[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*` と `[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-canary.[0-9]*`) に変更
- `verify-version` ジョブを新設し、`package.json` の `version` と `github.ref_name` を `node -p` 経由で比較。`permissions: contents: read` のみを明示してトップレベル `permissions:` の `id-token: write` 継承を断つ。`TAG_NAME` は step 単位の `env:` 経由で受け取り shell リテラルへの直接展開を避ける
- `build` ジョブに `needs: [verify-version]` を追加し、`verify-version` 失敗時は `build` も skip される間接ガード経路を確立
- canary 判定を `contains(github.ref, 'canary')` から `contains(github.ref_name, '-canary.')` の末尾区切り込み判定に変更

既存の publish step (`npm install -g npm@latest` / `npm publish --no-git-checks` / `--tag canary`) と `slack_notify` ジョブは無編集。

## 完了条件

- [x] `on.push.tags` を `"*"` から厳格 glob 2 つへ変更する
- [x] `jobs:` 直下、現行 `build:` の直前に `verify-version` ジョブを新設する
- [x] `build` の `runs-on:` の直後に `needs: [verify-version]` を追加する
- [x] canary 判定を `contains(github.ref_name, '-canary.')` / `!contains(github.ref_name, '-canary.')` に変更する
- [x] 既存の publish ステップは変更しない

## 検証

- bash の `case` 文で glob 挙動を補助確認 (CalVer 系は MATCH、`1.16.0` / `v2025.2.0` / `feature-canary-foo` は NO MATCH)
- `verify-version` スクリプトの一致 / 不一致経路をローカル実行で確認 (`TAG_NAME=2026.1.0-canary.1` で exit 0、`TAG_NAME=2025.2.0` で `::error::` + exit 1)
- tag push による実機 publish 経路の検証は誤 publish のリスクがあるため行わない (issue 完了条件で許容)

## 関連 issue

- issues/closed/0024-ci-fix-npm-publish-tag-version-mismatch.md