### PR TITLE
0026 e2e 系 workflow 5 本に permissions: 宣言がなく GITHUB_TOKEN が過剰権限になる問題を修正する

### DIFF
--- a/.github/workflows/e2e-test-canary.yml
+++ b/.github/workflows/e2e-test-canary.yml
@@ -17,6 +17,9 @@ on:
     # UTC 時間で毎日 2:00 (JST で 11:00) に実行、月曜日から金曜日
     - cron: "0 2 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test-canary:
     strategy:

--- a/.github/workflows/e2e-test-h265.yml
+++ b/.github/workflows/e2e-test-h265.yml
@@ -13,6 +13,9 @@ on:
     # UTC 時間で毎日 2:00 (JST で 11:00) に実行、月曜日から金曜日
     - cron: "0 2 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   # Chrome と Edge の Canary バージョンでのテスト
   # Playwright 経由では Canary バージョンのブラウザをインストールできない

--- a/.github/workflows/e2e-test-webkit.yml
+++ b/.github/workflows/e2e-test-webkit.yml
@@ -13,6 +13,9 @@ on:
     # UTC 時間で毎日 2:00 (JST で 11:00) に実行、月曜日から金曜日
     - cron: "0 2 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   # WebKit のテスト
   e2e-test-webkit:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,6 +14,9 @@ on:
     # UTC 時間で平日 1-7 時 (JST で 10:00-16:00) に 30 分ごとに実行
     - cron: "0,30 1-7 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     strategy:

--- a/.github/workflows/npm-pkg-e2e-test.yml
+++ b/.github/workflows/npm-pkg-e2e-test.yml
@@ -13,6 +13,9 @@ on:
     # UTC 時間で毎日 2:00 (JST で 11:00) に実行、月曜日から金曜日
     - cron: "0 2 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   npm-pkg-e2e-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,7 +7,6 @@ on:
       - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-canary.[0-9]*"
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@
   - @voluntas
 - [FIX] npm-publish workflow のタグトリガを厳格化し、タグ名と package.json の version が一致しない場合は publish 前に fail させる
   - @voluntas
+- [FIX] e2e 系 workflow 5 本に permissions: contents: read を追加し、npm-publish.yml の id-token: write をトップレベルから削除する
+  - @voluntas
 
 ## 2025.2.0
 

--- a/issues/closed/0026-ci-fix-workflows-missing-permissions.md
+++ b/issues/closed/0026-ci-fix-workflows-missing-permissions.md
@@ -3,6 +3,7 @@
 - Priority: High
 - Created: 2026-05-21
 - Polished: 2026-06-11
+- Completed: 2026-06-12
 - Model: Opus 4.7
 - Branch: feature/fix-workflows-permissions
 
@@ -122,3 +123,25 @@ permissions:
 ## マージ順
 
 `0024 → 0026 → 0033` を推奨する。0024 と本 issue はいずれも `npm-publish.yml` を編集するが、編集箇所は競合しない (0024 は `on.tags` / `if` / 新規 `verify-version` ジョブ、本 issue はトップレベル `permissions:` の 1 行削除)。技術的には本 issue を 0024 より先にマージしても構わないが、PR レビュー一貫性のため 0024 → 0026 の順で進める。0033 は publish ジョブレベル `id-token: write` の存在を前提とし、本 issue はその宣言には触れないため `0026 → 0033` の順で問題ない。
+
+## 解決方法
+
+### e2e 系 5 workflow にトップレベル `permissions: contents: read` を追加
+
+以下 5 ファイルの `on:` ブロック末尾と `jobs:` 行の間にある既存の空行と `jobs:` の間に `permissions:` / `  contents: read` の 2 行を挿入した。`ci.yaml:10-11` / `dependency-review.yml:10-11` と同じ配置・字下げで揃えている。
+
+- `.github/workflows/e2e-test.yml`
+- `.github/workflows/e2e-test-canary.yml`
+- `.github/workflows/e2e-test-h265.yml`
+- `.github/workflows/e2e-test-webkit.yml`
+- `.github/workflows/npm-pkg-e2e-test.yml`
+
+### `npm-publish.yml` のトップレベル `id-token: write` を削除
+
+`.github/workflows/npm-publish.yml` のトップレベル `permissions:` ブロックから `id-token: write` の 1 行のみを削除し、`contents: read` 単独の宣言に縮めた。`verify-version` / `npm-publish-canary` / `npm-publish` / `slack_notify` ジョブのジョブレベル `permissions:` 宣言には触れていない。
+
+### 検証
+
+- `actionlint -color .github/workflows/*.yml .github/workflows/*.yaml` を実行した。本変更で新たな warning は発生していない (既存の `Apple-M2-Pro` ラベル warning 2 件は self-hosted runner のカスタムラベル設定不在によるもので本 issue のスコープ外。develop と同じ件数のまま)。
+- SDK ソースコードを触っていないため `pnpm test` の追加実行は不要。
+- 各 workflow の `paths:` フィルタに自身の YAML が含まれているため、`feature/fix-workflows-permissions` ブランチへの push で自動発火する。発火後 Actions ログの「Set up job」ステップで `GITHUB_TOKEN Permissions` が `Contents: read` のみであることを確認する。


### PR DESCRIPTION
## 概要

e2e 系 5 workflow にトップレベル `permissions:` 宣言が無く、組織 default が `Read and write permissions` の場合に `GITHUB_TOKEN` が暗黙で `contents: write` 等を取得していた問題を、最小権限明示で修正する。あわせて `npm-publish.yml` のトップレベル `id-token: write` を削除して `build` ジョブへの過剰継承を解消する。

## 変更内容

- e2e 系 5 workflow (`e2e-test.yml` / `e2e-test-canary.yml` / `e2e-test-h265.yml` / `e2e-test-webkit.yml` / `npm-pkg-e2e-test.yml`) のトップレベルに `permissions: contents: read` を追加する。配置は `ci.yaml:10-11` / `dependency-review.yml:10-11` と同じ字下げ・空行構成に揃えた
- `npm-publish.yml` トップレベルから `id-token: write` の 1 行を削除し、`contents: read` 単独宣言にする。`verify-version` / `npm-publish-canary` / `npm-publish` / `slack_notify` のジョブレベル `permissions:` 宣言には触れない (publish 2 ジョブのジョブレベル `id-token: write` は維持)
- `CHANGES.md` の `## develop` `### misc` 末尾に `[FIX]` エントリを追記する
- issue 0026 を `issues/closed/` に移動し「## 解決方法」と `Completed: 2026-06-12` を追記する

## 完了条件

- [x] e2e 系 5 workflow に `permissions: contents: read` を追加する
- [x] `npm-publish.yml` トップレベルから `id-token: write` を 1 行削除する
- [x] 他のジョブレベル `permissions:` (publish 2 ジョブ、各 `slack_notify`、`verify-version`) は変更しない
- [x] `pnpm test` は SDK ソース無変更のため追加実行不要
- [x] `actionlint -color .github/workflows/*.yml .github/workflows/*.yaml` を実行し、本変更で新たな warning が増えていないことを確認した (既存の `Apple-M2-Pro` ラベル warning 2 件は self-hosted runner カスタムラベル設定不在に起因する既存事象で本 issue のスコープ外。`develop` と同じ件数で残る)
- [x] `CHANGES.md` `## develop` `### misc` 末尾に `[FIX]` エントリを追記する

## 関連 issue

- `issues/closed/0026-ci-fix-workflows-missing-permissions.md`