### PR TITLE
tsconfig.json を厳格化し src の型エラーを修正する

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -789,46 +789,46 @@ export default class ConnectionBase {
       }
     }
     // 終了処理を開始する
-    if (this.soraDataChannels.signaling) {
+    if (this.soraDataChannels["signaling"]) {
       const message = {
         reason: title,
         type: SIGNALING_MESSAGE_TYPE_DISCONNECT,
       };
-      if (this.signalingOfferMessageDataChannels.signaling?.compress === true) {
+      if (this.signalingOfferMessageDataChannels["signaling"]?.compress === true) {
         const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
         const compressedMessage = await compressMessage(binaryMessage);
-        if (this.soraDataChannels.signaling.readyState === "open") {
+        if (this.soraDataChannels["signaling"].readyState === "open") {
           // Firefox で readyState が open でも DataChannel send で例外がでる場合があるため処理する
           try {
-            this.soraDataChannels.signaling.send(compressedMessage);
+            this.soraDataChannels["signaling"].send(compressedMessage);
             this.writeDataChannelSignalingLog(
               "send-disconnect",
-              this.soraDataChannels.signaling,
+              this.soraDataChannels["signaling"],
               message,
             );
           } catch (error) {
             const errorMessage = (error as Error).message;
             this.writeDataChannelSignalingLog(
               "failed-to-send-disconnect",
-              this.soraDataChannels.signaling,
+              this.soraDataChannels["signaling"],
               errorMessage,
             );
           }
         }
-      } else if (this.soraDataChannels.signaling.readyState === "open") {
+      } else if (this.soraDataChannels["signaling"].readyState === "open") {
         // Firefox で readyState が open でも DataChannel send で例外がでる場合があるため処理する
         try {
-          this.soraDataChannels.signaling.send(JSON.stringify(message));
+          this.soraDataChannels["signaling"].send(JSON.stringify(message));
           this.writeDataChannelSignalingLog(
             "send-disconnect",
-            this.soraDataChannels.signaling,
+            this.soraDataChannels["signaling"],
             message,
           );
         } catch (error) {
           const errorMessage = (error as Error).message;
           this.writeDataChannelSignalingLog(
             "failed-to-send-disconnect",
-            this.soraDataChannels.signaling,
+            this.soraDataChannels["signaling"],
             errorMessage,
           );
         }
@@ -845,7 +845,11 @@ export default class ConnectionBase {
     await this.disconnectWebSocket(title);
     this.maybeClosePeerConnection();
     this.initializeConnection();
-    if (title === "WEBSOCKET-ONCLOSE" && params && (params.code === 1000 || params.code === 1005)) {
+    if (
+      title === "WEBSOCKET-ONCLOSE" &&
+      params &&
+      (params["code"] === 1000 || params["code"] === 1005)
+    ) {
       const event = this.soraCloseEvent("normal", "DISCONNECT", params);
       this.writeSoraTimelineLog("disconnect-normal", event);
       this.callbacks.disconnect(event);
@@ -975,7 +979,7 @@ export default class ConnectionBase {
     reason: string;
   }> {
     // label: signaling が存在しない場合は閉じて終了
-    if (!this.soraDataChannels.signaling) {
+    if (!this.soraDataChannels["signaling"]) {
       // それ以外の DataChannel を強制的に閉じる
       this.forceCloseDataChannels();
       return { code: 4999, reason: new DisconnectInternalError().message };
@@ -1016,44 +1020,44 @@ export default class ConnectionBase {
       reason: "NO-ERROR",
       type: SIGNALING_MESSAGE_TYPE_DISCONNECT,
     };
-    if (this.signalingOfferMessageDataChannels.signaling?.compress === true) {
+    if (this.signalingOfferMessageDataChannels["signaling"]?.compress === true) {
       const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
       const compressedMessage = await compressMessage(binaryMessage);
       if (
-        this.soraDataChannels.signaling?.readyState &&
-        this.soraDataChannels.signaling.readyState === "open"
+        this.soraDataChannels["signaling"]?.readyState &&
+        this.soraDataChannels["signaling"].readyState === "open"
       ) {
         // Firefox で readyState が open でも DataChannel send で例外がでる場合があるため処理する
         try {
-          this.soraDataChannels.signaling.send(compressedMessage);
+          this.soraDataChannels["signaling"].send(compressedMessage);
           this.writeDataChannelSignalingLog(
             "send-disconnect",
-            this.soraDataChannels.signaling,
+            this.soraDataChannels["signaling"],
             message,
           );
         } catch (error) {
           const errorMessage = (error as Error).message;
           this.writeDataChannelSignalingLog(
             "failed-to-send-disconnect",
-            this.soraDataChannels.signaling,
+            this.soraDataChannels["signaling"],
             errorMessage,
           );
         }
       }
-    } else if (this.soraDataChannels.signaling.readyState === "open") {
+    } else if (this.soraDataChannels["signaling"].readyState === "open") {
       // Firefox で readyState が open でも DataChannel send で例外がでる場合があるため処理する
       try {
-        this.soraDataChannels.signaling.send(JSON.stringify(message));
+        this.soraDataChannels["signaling"].send(JSON.stringify(message));
         this.writeDataChannelSignalingLog(
           "send-disconnect",
-          this.soraDataChannels.signaling,
+          this.soraDataChannels["signaling"],
           message,
         );
       } catch (error) {
         const errorMessage = (error as Error).message;
         this.writeDataChannelSignalingLog(
           "failed-to-send-disconnect",
-          this.soraDataChannels.signaling,
+          this.soraDataChannels["signaling"],
           errorMessage,
         );
       }
@@ -1193,6 +1197,11 @@ export default class ConnectionBase {
         typeof signalingUrlCandidates === "string"
           ? signalingUrlCandidates
           : signalingUrlCandidates[0];
+      // noUncheckedIndexedAccess により signalingUrlCandidates[0] は string | undefined になる
+      // length === 1 のチェック直後なのでランタイムでは undefined にならないが、型を絞り込むため明示的にチェックする
+      if (signalingUrl === undefined) {
+        throw new ConnectError("Signaling failed. signalingUrl is undefined.");
+      }
       return new Promise((resolve, reject) => {
         const ws = new WebSocket(signalingUrl);
         ws.onclose = (event): void => {
@@ -2470,17 +2479,17 @@ export default class ConnectionBase {
     type: string;
     [key: string]: unknown;
   }): Promise<void> {
-    if (this.soraDataChannels.signaling) {
-      if (this.signalingOfferMessageDataChannels.signaling?.compress === true) {
+    if (this.soraDataChannels["signaling"]) {
+      if (this.signalingOfferMessageDataChannels["signaling"]?.compress === true) {
         const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
         const compressedMessage = await compressMessage(binaryMessage);
-        this.soraDataChannels.signaling.send(compressedMessage);
+        this.soraDataChannels["signaling"].send(compressedMessage);
       } else {
-        this.soraDataChannels.signaling.send(JSON.stringify(message));
+        this.soraDataChannels["signaling"].send(JSON.stringify(message));
       }
       this.writeDataChannelSignalingLog(
         `send-${message.type}`,
-        this.soraDataChannels.signaling,
+        this.soraDataChannels["signaling"],
         message,
       );
     } else if (this.ws !== null) {
@@ -2495,17 +2504,17 @@ export default class ConnectionBase {
    * @param reports - RTCStatsReport のリスト
    */
   private async sendStatsMessage(reports: RTCStatsReport[]): Promise<void> {
-    if (this.soraDataChannels.stats) {
+    if (this.soraDataChannels["stats"]) {
       const message = {
         reports,
         type: SIGNALING_MESSAGE_TYPE_STATS,
       };
-      if (this.signalingOfferMessageDataChannels.stats?.compress === true) {
+      if (this.signalingOfferMessageDataChannels["stats"]?.compress === true) {
         const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
         const compressedMessage = await compressMessage(binaryMessage);
-        this.soraDataChannels.stats.send(compressedMessage);
+        this.soraDataChannels["stats"].send(compressedMessage);
       } else {
-        this.soraDataChannels.stats.send(JSON.stringify(message));
+        this.soraDataChannels["stats"].send(JSON.stringify(message));
       }
     }
   }
@@ -2646,11 +2655,15 @@ export default class ConnectionBase {
       const messagingDataChannel: DataChannelConfiguration = {
         compress: settings.compress,
         direction: settings.direction,
-        header: settings.header,
         label: dataChannel.label,
         ordered: dataChannel.ordered,
         protocol: dataChannel.protocol,
       };
+      // exactOptionalPropertyTypes 対応のため、optional プロパティは undefined ではなく
+      // プロパティ自体を含めないよう条件で代入する
+      if (settings.header !== undefined) {
+        messagingDataChannel.header = settings.header;
+      }
       if (typeof dataChannel.maxPacketLifeTime === "number") {
         messagingDataChannel.maxPacketLifeTime = dataChannel.maxPacketLifeTime;
       }
@@ -2682,7 +2695,7 @@ export default class ConnectionBase {
     params?: Record<string, unknown> | unknown[],
     options?: RPCOptions,
   ): Promise<T> {
-    const rpcDataChannel = this.soraDataChannels.rpc;
+    const rpcDataChannel = this.soraDataChannels["rpc"];
     if (rpcDataChannel?.readyState !== "open") {
       throw new Error("RPC DataChannel is not available or not open");
     }
@@ -2690,24 +2703,24 @@ export default class ConnectionBase {
     // notification の場合は id を含めない
     const isNotification = options?.notification === true;
     const id = isNotification ? undefined : ++this.rpcRequestIdCounter;
-    const request: JSONRPCRequest = isNotification
-      ? {
-          jsonrpc: "2.0",
-          method,
-          params,
-        }
-      : {
-          id,
-          jsonrpc: "2.0",
-          method,
-          params,
-        };
+    // exactOptionalPropertyTypes 対応のため、optional プロパティは undefined ではなく
+    // プロパティ自体を含めないよう条件で代入する
+    const request: JSONRPCRequest = {
+      jsonrpc: "2.0",
+      method,
+    };
+    if (id !== undefined) {
+      request.id = id;
+    }
+    if (params !== undefined) {
+      request.params = params;
+    }
 
     return new Promise<T>((resolve, reject) => {
       // notification の場合はレスポンスを待たずに即座に resolve
       if (isNotification) {
         const message = JSON.stringify(request);
-        const dataChannelSettings = this.signalingOfferMessageDataChannels.rpc;
+        const dataChannelSettings = this.signalingOfferMessageDataChannels["rpc"];
 
         if (dataChannelSettings?.compress) {
           compressMessage(new TextEncoder().encode(message))
@@ -2767,7 +2780,7 @@ export default class ConnectionBase {
       });
 
       const message = JSON.stringify(request);
-      const dataChannelSettings = this.signalingOfferMessageDataChannels.rpc;
+      const dataChannelSettings = this.signalingOfferMessageDataChannels["rpc"];
 
       if (dataChannelSettings?.compress) {
         compressMessage(new TextEncoder().encode(message))

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -39,6 +39,11 @@ export default class ConnectionSubscriber extends ConnectionBase {
     if (this.pc) {
       this.pc.ontrack = (event): void => {
         const stream = event.streams[0];
+        // noUncheckedIndexedAccess により event.streams[0] は MediaStream | undefined になる
+        // stream が存在しない場合は以降の処理を行わない
+        if (!stream) {
+          return;
+        }
         if (stream.id === "default") {
           return;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -543,8 +543,14 @@ export class ConnectError extends Error {
   constructor(message: string, code?: number, reason?: string) {
     super(message);
     this.name = "ConnectError";
-    this.code = code;
-    this.reason = reason;
+    // exactOptionalPropertyTypes 対応のため、optional プロパティは undefined ではなく
+    // プロパティ自体を含めないよう条件で代入する
+    if (code !== undefined) {
+      this.code = code;
+    }
+    if (reason !== undefined) {
+      this.reason = reason;
+    }
   }
 }
 
@@ -597,8 +603,14 @@ export function createTimelineEvent(
     event.data = data;
   }
   event.logType = logType;
-  event.dataChannelId = dataChannelId;
-  event.dataChannelLabel = dataChannelLabel;
+  // exactOptionalPropertyTypes 対応のため、optional プロパティは undefined ではなく
+  // プロパティ自体を含めないよう条件で代入する
+  if (dataChannelId !== undefined) {
+    event.dataChannelId = dataChannelId;
+  }
+  if (dataChannelLabel !== undefined) {
+    event.dataChannelLabel = dataChannelLabel;
+  }
   return event;
 }
 
@@ -648,10 +660,17 @@ export function addStereoToFmtp(sdp: string): string {
   }
 
   const sessionDescription = splitSdp[1];
+  const mediaSection = splitSdp[2];
+  // noUncheckedIndexedAccess により splitSdp[1] / splitSdp[2] は string | undefined になる
+  // 正規表現が両方のキャプチャグループにマッチしているのでランタイムでは undefined にならないが、
+  // 型を絞り込むため明示的にチェックする
+  if (sessionDescription === undefined || mediaSection === undefined) {
+    return sdp;
+  }
 
   const mediaDescriptionsList: string[][] = [];
   let mediaDescriptionList: string[] = [];
-  for (const line of splitSdp[2].split(/\n/u)) {
+  for (const line of mediaSection.split(/\n/u)) {
     const typ = line[0];
     if (typ === "m") {
       mediaDescriptionList = [line];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,90 @@
 {
   "compilerOptions": {
+    // === 出力ターゲット ===
+    // コンパイル後の JavaScript の ECMAScript バージョン
     "target": "ES2022",
+    // 生成するモジュールシステム (ESM 出力)
     "module": "ES2022",
+    // strict ファミリーを一括有効化
+    // (noImplicitAny / strictNullChecks / strictFunctionTypes /
+    //  strictBindCallApply / strictPropertyInitialization /
+    //  alwaysStrict / noImplicitThis / useUnknownInCatchVariables)
     "strict": true,
+
+    // === 型定義ファイル (.d.ts) 出力 ===
+    // .d.ts 型定義ファイルを生成する (公開 SDK のため必須)
     "declaration": true,
+    // .d.ts の出力先ディレクトリ
     "declarationDir": "./dist",
+    // ソースのルートディレクトリ (出力ディレクトリ構造の基点)
     "rootDir": "./src",
-    "strictNullChecks": true,
-    "importHelpers": true,
-    "moduleResolution": "Bundler",
-    "experimentalDecorators": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
+    // @internal タグが付いた宣言を .d.ts から除外する (内部 API を隠蔽)
     "stripInternal": true,
+
+    // === モジュール解決 / 相互運用 ===
+    // __extends / __awaiter 等のヘルパーを tslib から import する (バンドルサイズ削減)
+    "importHelpers": true,
+    // モジュール解決方式 (vite / esbuild など最新バンドラ向け)
+    "moduleResolution": "Bundler",
+    // CommonJS モジュールと ES Module の相互運用を有効化する
+    "esModuleInterop": true,
+    // default export を持たないモジュールから default import することを型上許容する
+    "allowSyntheticDefaultImports": true,
+    // .json ファイルを import 可能にする
+    "resolveJsonModule": true,
+
+    // === コード品質: 未使用検出 ===
     // 未使用のローカル変数をエラーにする
     "noUnusedLocals": true,
     // 未使用のパラメータをエラーにする
     "noUnusedParameters": true,
-    // 関数の引数の型を厳密にチェックする
-    "strictFunctionTypes": true,
-    // プロパティの初期化を厳密にチェックする
-    "strictPropertyInitialization": true,
-    "newLine": "LF",
+    // 未使用のラベルをエラーにする
+    "allowUnusedLabels": false,
+    // 到達不能コードをエラーにする
+    "allowUnreachableCode": false,
+
+    // === コード品質: 制御フロー ===
+    // 関数のすべてのコードパスが値を返すことを強制する
+    "noImplicitReturns": true,
+    // switch 文の case のフォールスルーを禁止する
+    "noFallthroughCasesInSwitch": true,
+
+    // === 型: 厳格化追加 ===
+    // インデックスアクセス (arr[i] や map[key]) の結果に undefined を含める
+    "noUncheckedIndexedAccess": true,
+    // オプショナルプロパティ (?:) と「明示的に undefined」を別物として扱う
+    "exactOptionalPropertyTypes": true,
+    // インデックスシグネチャ越しのプロパティアクセスをドット記法で許さない
+    "noPropertyAccessFromIndexSignature": true,
+    // override キーワードの付け忘れをエラーにする
+    "noImplicitOverride": true,
+
+    // === モジュール: 厳格化 ===
+    // 各ファイルを単独でトランスパイル可能であることを保証する (vite / esbuild 前提)
+    "isolatedModules": true,
+    // import / export の構文を厳密にする (type のみの import を明示する必要がある)
+    "verbatimModuleSyntax": true,
+    // ファイル名の大文字小文字の不一致をエラーにする (TS 5.0+ で既定 true だが明示)
+    "forceConsistentCasingInFileNames": true,
+    // クラスフィールドの初期化を Object.defineProperty 相当にする (ES2022 既定挙動)
+    "useDefineForClassFields": true,
+
+    // === エラー報告: 省略させない ===
+    // 型エラーメッセージの省略を無効化する (原因特定を容易にする)
+    "noErrorTruncation": true,
+    // ライブラリ側の型エラーも検出する (skipLibCheck をあえて切る)
+    "skipLibCheck": false,
+    // 暗黙的に @types/* を取り込まない (必要なものは明示的に import する)
     "types": [],
+
+    // === 出力フォーマット ===
+    // 生成ファイルの改行コードを LF に統一する
+    "newLine": "LF",
+    // 利用可能な組み込み型ライブラリ (DOM API と最新の ECMAScript API)
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
+  // 型チェック対象 (src 配下の .ts のみ)
   "include": ["src/**/*.ts"],
+  // 型チェック対象から除外する (依存パッケージとテストは別 tsconfig 管理)
   "exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
## 概要

`tsconfig.json` に厳格化オプションを追加して strict 度合いを最大化し、それに伴って顕在化した `src` 配下の型エラー 49 件を修正する。

## 変更内容

- `tsconfig.json` に厳格化オプションを 14 個追加する
  - 制御フロー系: `noImplicitReturns` / `noFallthroughCasesInSwitch` / `allowUnreachableCode: false` / `allowUnusedLabels: false`
  - 型厳格系: `noUncheckedIndexedAccess` / `exactOptionalPropertyTypes` / `noPropertyAccessFromIndexSignature` / `noImplicitOverride`
  - モジュール系: `isolatedModules` / `verbatimModuleSyntax` / `forceConsistentCasingInFileNames` / `useDefineForClassFields`
  - エラー報告系: `noErrorTruncation` / `skipLibCheck: false` (明示で OFF)
- 冗長または未使用の設定 (`experimentalDecorators` / `strictNullChecks` / `strictFunctionTypes` / `strictPropertyInitialization`) を削除する
- 全コンパイラオプションに日本語コメントを付与して用途別にセクション化する
- `src/base.ts` の index signature プロパティ (`signaling` / `stats` / `rpc` / `code`) へのアクセス 35 箇所をブラケット記法に統一する
- `src/base.ts:1197` の `signalingUrlCandidates[0]` が `string | undefined` になる問題を防御 `throw` で吸収する
- `src/base.ts:2651` の `DataChannelConfiguration.header` を条件代入に変更する
- `src/base.ts:2698` の `JSONRPCRequest.id` / `params` を条件代入に変更する
- `src/subscriber.ts:42` の `event.streams[0]` に対して publisher.ts と同形の undefined ガードを追加する
- `src/utils.ts` の `ConnectError` コンストラクタ / `createTimelineEvent` / `addStereoToFmtp` の型エラーを修正する

## 完了条件

- [x] `pnpm typecheck` がエラー 0 件で通る
- [x] `pnpm build` が成功する (`dist/sora.js` 57.95 kB / gzip 11.91 kB)
- [x] `pnpm lint --type-aware` が警告 0 件で通る
- [x] `pnpm test` の 105 件全てが pass する
- [x] pre-commit フック (`vp check` / `tsc --noEmit` / `vp test`) 全通過

## 関連 issue

なし (ユーザー指示による即時対応)