### PR TITLE
0034 sendSignalingMessage / sendStatsMessage の readyState ガードを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,8 @@
   - @voluntas
 - [FIX] abend() の abend 分岐で SoraCloseEvent を 2 回生成して timeline と callback に別インスタンスを渡していたのを 1 つのインスタンスを共有するように修正する
   - @voluntas
+- [FIX] sendSignalingMessage / sendStatsMessage で送信前に readyState を確認し、open 以外の状態での送信を防ぐようにする
+  - @voluntas
 
 ### misc
 

--- a/issues/closed/0034-bug-fix-signaling-send-sync-exceptions.md
+++ b/issues/closed/0034-bug-fix-signaling-send-sync-exceptions.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-25
+- Completed: 2026-06-14
 - Polished: 2026-06-14
 - Model: Composer 2.5
 - Branch: feature/fix-signaling-send-sync-exceptions
@@ -135,6 +136,21 @@ private async sendStatsMessage(reports: RTCStatsReport[]): Promise<void> {
   - [FIX] sendSignalingMessage / sendStatsMessage で送信前に readyState を確認し、open 以外の状態での送信を防ぐ
     - @voluntas
   ```
+
+## 解決方法
+
+`src/base.ts` の `sendSignalingMessage` / `sendStatsMessage` において、`DataChannel.send` / `ws.send` を呼ぶ前に `readyState` が open であることを確認するガードを追加した。
+
+- `sendSignalingMessage`
+  - `compress === false` の DataChannel 送信分岐に `readyState === "open"` ガードを追加
+  - WebSocket 送信分岐に `readyState === 1` ガードを追加
+  - `compress === true` 分岐は issue 0040 の機能検出設計完了後に別途扱うため、本 issue では現状維持
+  - JSDoc に「compress 分岐を除き、open でない場合は送信をスキップすること」を追記
+- `sendStatsMessage`
+  - DataChannel 送信分岐に `readyState === "open"` ガードを追加
+  - `compress === true` 分岐は `sendSignalingMessage` と同様に現状維持
+  - JSDoc に「compress 分岐を除き、open でない場合は送信をスキップすること」を追記
+- `CHANGES.md` の `## develop` セクションに `[FIX]` エントリを追加
 
 ## 関連 issue
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -2473,6 +2473,9 @@ export default class ConnectionBase {
   /**
    * シグナリングサーバーへメッセージを送信するメソッド
    *
+   * compress 分岐を除き、DataChannel / WebSocket が open でない場合は送信をスキップする。
+   * これは切断進行中に同期例外を防ぐためである。
+   *
    * @param message - 送信するメッセージ
    */
   private async sendSignalingMessage(message: {
@@ -2481,25 +2484,34 @@ export default class ConnectionBase {
   }): Promise<void> {
     if (this.soraDataChannels["signaling"]) {
       if (this.signalingOfferMessageDataChannels["signaling"]?.compress === true) {
+        // compress 分岐には readyState ガードを入れない
         const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
         const compressedMessage = await compressMessage(binaryMessage);
         this.soraDataChannels["signaling"].send(compressedMessage);
-      } else {
+        this.writeDataChannelSignalingLog(
+          `send-${message.type}`,
+          this.soraDataChannels["signaling"],
+          message,
+        );
+      } else if (this.soraDataChannels["signaling"].readyState === "open") {
         this.soraDataChannels["signaling"].send(JSON.stringify(message));
+        this.writeDataChannelSignalingLog(
+          `send-${message.type}`,
+          this.soraDataChannels["signaling"],
+          message,
+        );
       }
-      this.writeDataChannelSignalingLog(
-        `send-${message.type}`,
-        this.soraDataChannels["signaling"],
-        message,
-      );
-    } else if (this.ws !== null) {
+    } else if (this.ws?.readyState === 1) {
       this.ws.send(JSON.stringify(message));
       this.writeWebSocketSignalingLog(`send-${message.type}`, message);
     }
   }
 
   /**
-   * シグナリングサーバーに stats メッセージを投げるメソッド
+   * シグナリングサーバーに stats メッセージを送信するメソッド
+   *
+   * compress 分岐を除き、DataChannel が open でない場合は送信をスキップする。
+   * これは切断進行中に同期例外を防ぐためである。
    *
    * @param reports - RTCStatsReport のリスト
    */
@@ -2510,10 +2522,11 @@ export default class ConnectionBase {
         type: SIGNALING_MESSAGE_TYPE_STATS,
       };
       if (this.signalingOfferMessageDataChannels["stats"]?.compress === true) {
+        // compress 分岐には readyState ガードを入れない
         const binaryMessage = new TextEncoder().encode(JSON.stringify(message));
         const compressedMessage = await compressMessage(binaryMessage);
         this.soraDataChannels["stats"].send(compressedMessage);
-      } else {
+      } else if (this.soraDataChannels["stats"].readyState === "open") {
         this.soraDataChannels["stats"].send(JSON.stringify(message));
       }
     }


### PR DESCRIPTION
## 概要

`sendSignalingMessage` / `sendStatsMessage` の `DataChannel.send` / `ws.send` に readyState ガードを追加し、open 以外の状態での同期例外を防ぐ。

## 変更内容

- `sendSignalingMessage` の `compress === false` 分岐と WebSocket 分岐に readyState ガードを追加
- `sendStatsMessage` の DataChannel 送信箇所に readyState ガードを追加
- `compress === true` 分岐は機能検出設計完了後に別途扱うため現状維持
- `CHANGES.md` に `[FIX]` エントリを追加

## 完了条件

- [x] `sendSignalingMessage` の `compress === false` 分岐と ws 分岐に readyState ガードを入れる
- [x] `sendStatsMessage` の DataChannel 送信箇所に readyState ガードを入れる
- [x] `compressMessage` 関連は本 issue では触らない
- [x] `vp test run` が通る
- [x] `vp build && playwright test --project='chromium'` が通る
- [x] `CHANGES.md` `## develop` 直下に [FIX] エントリを追記

## 関連 issue

- issues/closed/0034-bug-fix-signaling-send-sync-exceptions.md