### PR TITLE
0028 e2e-tests の fake media 生成で connect/disconnect 繰り返し時に RAF / AudioContext が解放されない問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,8 @@
   - @voluntas
 - [FIX] e2e 系 workflow 5 本に permissions: contents: read を追加し、npm-publish.yml の id-token: write をトップレベルから削除する
   - @voluntas
+- [FIX] e2e-tests の fake media 生成に明示的 cleanup() を追加し connect/disconnect 繰り返し時の RAF / AudioContext リークを防ぐ
+  - @voluntas
 
 ## 2025.2.0
 

--- a/e2e-tests/fake_sendonly/main.ts
+++ b/e2e-tests/fake_sendonly/main.ts
@@ -18,10 +18,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   setSoraJsSdkVersion();
 
   let client: SoraClient;
+  // getFakeMedia の cleanup を保持し、#disconnect / 次回 #connect / connect 失敗時に解放する。
+  let fakeCleanup: (() => void) | null = null;
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
-    if (client) {
-      await client.disconnect();
+    // 旧 client.disconnect が throw しても fake stream は必ず解放してから新しい stream を生成する。
+    try {
+      if (client) {
+        await client.disconnect();
+      }
+    } finally {
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
     }
 
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
@@ -31,17 +41,35 @@ document.addEventListener("DOMContentLoaded", async () => {
     const useFakeAudio = document.querySelector<HTMLInputElement>("#use-fake-audio")!.checked;
     const useFakeVideo = document.querySelector<HTMLInputElement>("#use-fake-video")!.checked;
 
-    const stream = getFakeMedia({
+    const { stream, cleanup } = getFakeMedia({
       audio: useFakeAudio,
       video: useFakeVideo,
     });
+    fakeCleanup = cleanup;
 
-    await client.connect(stream);
+    try {
+      await client.connect(stream);
+    } catch (error) {
+      // connect 失敗時にも fake stream を解放してリソースリークを防ぐ。
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+      throw error;
+    }
   });
 
   document.querySelector("#disconnect")?.addEventListener("click", async () => {
-    if (client) {
-      await client.disconnect();
+    // client.disconnect が throw しても fake stream は必ず解放する。
+    try {
+      if (client) {
+        await client.disconnect();
+      }
+    } finally {
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
     }
   });
 

--- a/e2e-tests/fake_stereo_audio/main.ts
+++ b/e2e-tests/fake_stereo_audio/main.ts
@@ -138,6 +138,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   let recvClient: SoraRecvClient;
   let localAnalyzer: RealtimeAudioAnalyzer | null = null;
   let remoteAnalyzer: RealtimeAudioAnalyzer | null = null;
+  // getFakeMedia の cleanup を保持し、#disconnect / 次回 #connect / connect 失敗時に解放する。
+  let fakeCleanup: (() => void) | null = null;
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
@@ -166,13 +168,20 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const useStereo = document.querySelector<HTMLInputElement>("#use-stereo")!.checked;
 
-    const stream = getFakeMedia({
+    // 既存の cleanup が残っていれば解放してから新しい stream を生成する。
+    // 手動操作で同一 page 内の再接続が起きた場合の防御。
+    if (fakeCleanup) {
+      fakeCleanup();
+      fakeCleanup = null;
+    }
+    const { stream, cleanup } = getFakeMedia({
       audio: {
         frequency: 440,
         stereo: useStereo,
         volume: 0.1,
       },
     });
+    fakeCleanup = cleanup;
 
     // ローカル音声のリアルタイム解析を開始
     if (localAnalyzer) {
@@ -181,23 +190,40 @@ document.addEventListener("DOMContentLoaded", async () => {
     localAnalyzer = new RealtimeAudioAnalyzer(stream, "local");
     localAnalyzer.start();
 
-    await sendClient.connect(stream);
+    try {
+      await sendClient.connect(stream);
+    } catch (error) {
+      // connect 失敗時にも fake stream を解放してリソースリークを防ぐ。
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+      throw error;
+    }
   });
 
   document.querySelector("#disconnect")?.addEventListener("click", async () => {
-    if (localAnalyzer) {
-      localAnalyzer.stop();
-      localAnalyzer = null;
-    }
-    if (remoteAnalyzer) {
-      remoteAnalyzer.stop();
-      remoteAnalyzer = null;
-    }
-    if (sendClient) {
-      await sendClient.disconnect();
-    }
-    if (recvClient) {
-      await recvClient.disconnect();
+    // sendClient / recvClient の disconnect が throw しても fake stream は必ず解放する。
+    try {
+      if (localAnalyzer) {
+        localAnalyzer.stop();
+        localAnalyzer = null;
+      }
+      if (remoteAnalyzer) {
+        remoteAnalyzer.stop();
+        remoteAnalyzer = null;
+      }
+      if (sendClient) {
+        await sendClient.disconnect();
+      }
+      if (recvClient) {
+        await recvClient.disconnect();
+      }
+    } finally {
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
     }
   });
 

--- a/e2e-tests/fake_stereo_audio_sendrecv/main.ts
+++ b/e2e-tests/fake_stereo_audio_sendrecv/main.ts
@@ -135,6 +135,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   let remoteAnalyzer1: RealtimeAudioAnalyzer | null = null;
   let localAnalyzer2: RealtimeAudioAnalyzer | null = null;
   let remoteAnalyzer2: RealtimeAudioAnalyzer | null = null;
+  // 接続 1 / 接続 2 の fake stream 由来 cleanup を個別に保持する。
+  let fakeCleanup1: (() => void) | null = null;
+  let fakeCleanup2: (() => void) | null = null;
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
@@ -155,14 +158,20 @@ document.addEventListener("DOMContentLoaded", async () => {
       soraClient1.setForceStereoOutput(true);
     }
 
+    // 既存の cleanup が残っていれば解放してから新しい stream を生成する。
+    if (fakeCleanup1) {
+      fakeCleanup1();
+      fakeCleanup1 = null;
+    }
     // 接続1用の音声ストリームを生成（440Hz基準）
-    const stream1 = getFakeMedia({
+    const { stream: stream1, cleanup: cleanup1 } = getFakeMedia({
       audio: {
         frequency: 440,
         stereo: useStereo1,
         volume: 0.1,
       },
     });
+    fakeCleanup1 = cleanup1;
 
     // 接続1のローカル音声解析を開始
     if (localAnalyzer1) {
@@ -181,7 +190,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     // 接続1を開始
-    await soraClient1.connect(stream1);
+    try {
+      await soraClient1.connect(stream1);
+    } catch (error) {
+      // connect 失敗時にも接続 1 の fake stream を解放する。
+      if (fakeCleanup1) {
+        fakeCleanup1();
+        fakeCleanup1 = null;
+      }
+      throw error;
+    }
 
     // 少し待機してから接続2を開始
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -192,14 +210,20 @@ document.addEventListener("DOMContentLoaded", async () => {
       soraClient2.setForceStereoOutput(true);
     }
 
+    // 既存の cleanup が残っていれば解放してから新しい stream を生成する。
+    if (fakeCleanup2) {
+      fakeCleanup2();
+      fakeCleanup2 = null;
+    }
     // 接続2用の音声ストリームを生成（880Hz基準、接続1と区別するため）
-    const stream2 = getFakeMedia({
+    const { stream: stream2, cleanup: cleanup2 } = getFakeMedia({
       audio: {
         frequency: 880,
         stereo: useStereo2,
         volume: 0.1,
       },
     });
+    fakeCleanup2 = cleanup2;
 
     // 接続2のローカル音声解析を開始
     if (localAnalyzer2) {
@@ -218,33 +242,54 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     // 接続2を開始
-    await soraClient2.connect(stream2);
+    try {
+      await soraClient2.connect(stream2);
+    } catch (error) {
+      // connect 失敗時にも接続 2 の fake stream を解放する。
+      if (fakeCleanup2) {
+        fakeCleanup2();
+        fakeCleanup2 = null;
+      }
+      throw error;
+    }
   });
 
   document.querySelector("#disconnect")?.addEventListener("click", async () => {
-    if (localAnalyzer1) {
-      localAnalyzer1.stop();
-      localAnalyzer1 = null;
-    }
-    if (remoteAnalyzer1) {
-      remoteAnalyzer1.stop();
-      remoteAnalyzer1 = null;
-    }
-    if (localAnalyzer2) {
-      localAnalyzer2.stop();
-      localAnalyzer2 = null;
-    }
-    if (remoteAnalyzer2) {
-      remoteAnalyzer2.stop();
-      remoteAnalyzer2 = null;
-    }
-    if (soraClient1) {
-      await soraClient1.disconnect();
-      soraClient1 = null;
-    }
-    if (soraClient2) {
-      await soraClient2.disconnect();
-      soraClient2 = null;
+    // analyzer.stop / client.disconnect が throw しても fake stream は必ず解放する。
+    try {
+      if (localAnalyzer1) {
+        localAnalyzer1.stop();
+        localAnalyzer1 = null;
+      }
+      if (remoteAnalyzer1) {
+        remoteAnalyzer1.stop();
+        remoteAnalyzer1 = null;
+      }
+      if (localAnalyzer2) {
+        localAnalyzer2.stop();
+        localAnalyzer2 = null;
+      }
+      if (remoteAnalyzer2) {
+        remoteAnalyzer2.stop();
+        remoteAnalyzer2 = null;
+      }
+      if (soraClient1) {
+        await soraClient1.disconnect();
+        soraClient1 = null;
+      }
+      if (soraClient2) {
+        await soraClient2.disconnect();
+        soraClient2 = null;
+      }
+    } finally {
+      if (fakeCleanup1) {
+        fakeCleanup1();
+        fakeCleanup1 = null;
+      }
+      if (fakeCleanup2) {
+        fakeCleanup2();
+        fakeCleanup2 = null;
+      }
     }
   });
 

--- a/e2e-tests/sendrecv_webkit/main.ts
+++ b/e2e-tests/sendrecv_webkit/main.ts
@@ -18,21 +18,48 @@ document.addEventListener("DOMContentLoaded", async () => {
   setSoraJsSdkVersion();
 
   let client: SoraClient;
+  // getFakeMedia の cleanup を保持し、#disconnect / 次回 #connect / connect 失敗時に解放する。
+  let fakeCleanup: (() => void) | null = null;
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
     const videoCodecType = getVideoCodecType();
 
+    // 既存の cleanup が残っていれば解放してから新しい stream を生成する。
+    if (fakeCleanup) {
+      fakeCleanup();
+      fakeCleanup = null;
+    }
+
     client = new SoraClient(signalingUrl, channelId, secretKey, videoCodecType);
 
-    const stream = getFakeMedia({
+    const { stream, cleanup } = getFakeMedia({
       audio: true,
       video: true,
     });
-    await client.connect(stream);
+    fakeCleanup = cleanup;
+
+    try {
+      await client.connect(stream);
+    } catch (error) {
+      // connect 失敗時にも fake stream を解放してリソースリークを防ぐ。
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+      throw error;
+    }
   });
   document.querySelector("#disconnect")?.addEventListener("click", async () => {
-    await client.disconnect();
+    // client.disconnect が throw しても fake stream は必ず解放する。
+    try {
+      await client.disconnect();
+    } finally {
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+    }
   });
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {

--- a/e2e-tests/simulcast_sendonly_webkit/main.ts
+++ b/e2e-tests/simulcast_sendonly_webkit/main.ts
@@ -17,6 +17,8 @@ document.addEventListener("DOMContentLoaded", () => {
   setSoraJsSdkVersion();
 
   let sendonly: SimulcastSendonlySoraClient;
+  // getFakeMedia の cleanup を保持し、#disconnect / 次回 #connect / connect 失敗時に解放する。
+  let fakeCleanup: (() => void) | null = null;
 
   document.querySelector("#connect")?.addEventListener("click", async () => {
     const channelId = getChannelId(channelIdPrefix, channelIdSuffix);
@@ -38,6 +40,12 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
 
+    // 既存の cleanup が残っていれば解放してから新しい stream を生成する。
+    if (fakeCleanup) {
+      fakeCleanup();
+      fakeCleanup = null;
+    }
+
     sendonly = new SimulcastSendonlySoraClient(
       signalingUrl,
       channelId,
@@ -47,15 +55,34 @@ document.addEventListener("DOMContentLoaded", () => {
       secretKey,
     );
 
-    const stream = getFakeMedia({
+    const { stream, cleanup } = getFakeMedia({
       audio: false,
       video: { height: 540, width: 960 },
     });
-    await sendonly.connect(stream);
+    fakeCleanup = cleanup;
+
+    try {
+      await sendonly.connect(stream);
+    } catch (error) {
+      // connect 失敗時にも fake stream を解放してリソースリークを防ぐ。
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+      throw error;
+    }
   });
 
   document.querySelector("#disconnect")?.addEventListener("click", async () => {
-    await sendonly.disconnect();
+    // sendonly.disconnect が throw しても fake stream は必ず解放する。
+    try {
+      await sendonly.disconnect();
+    } finally {
+      if (fakeCleanup) {
+        fakeCleanup();
+        fakeCleanup = null;
+      }
+    }
   });
 
   document.querySelector("#get-stats")?.addEventListener("click", async () => {

--- a/e2e-tests/src/fake.ts
+++ b/e2e-tests/src/fake.ts
@@ -31,11 +31,21 @@ const generateColors = (): { bgColor: string; contrastColor: string } => {
   return { bgColor, contrastColor };
 };
 
+// AudioContext.close() の Promise rejection を処理する。
+// 既に closed の場合は InvalidStateError が投げられるため、ここだけ無視して
+// それ以外は console.error に出すことで cleanup の異常を可視化する。
+const handleAudioContextCloseError = (error: unknown): void => {
+  if (error instanceof DOMException && error.name === "InvalidStateError") {
+    return;
+  }
+  console.error("AudioContext.close() の実行に失敗しました:", error);
+};
+
 const createFakeVideoTrack = (
   width = 320, // デフォルト幅 320px
   height = 240, // デフォルト高さ 240px
   frameRate = 30, // デフォルトフレームレート 30fps
-): MediaStreamTrack => {
+): { track: MediaStreamTrack; cleanup: () => void } => {
   // フレームレートを制限
   const fps = Math.max(MIN_FPS, Math.min(MAX_FPS, frameRate));
 
@@ -53,7 +63,10 @@ const createFakeVideoTrack = (
   // 開始時間とフレームカウンター
   const startTime = Date.now();
   let frameCount = 0;
-  let animationFrameId: number;
+  // cleanup 済みのとき RAF のキャンセル対象が無いケースを表せるよう undefined を初期値にする。
+  let animationFrameId: number | undefined;
+  // cleanup が 2 回以上呼ばれても no-op にするためのガード。
+  let cleaned = false;
 
   // 色を決定
   const { bgColor, contrastColor } = generateColors();
@@ -67,6 +80,11 @@ const createFakeVideoTrack = (
 
   // キャンバスを更新する関数 (requestAnimationFrameを使用)
   const updateCanvas = (): void => {
+    // cleanup() 直後に RAF コールバックがすでにキューされている場合があるため、
+    // 冒頭でフラグをチェックして再スケジュールしないようにする。
+    if (cleaned) {
+      return;
+    }
     frameCount++;
     const elapsedTime = Date.now() - startTime;
 
@@ -124,20 +142,36 @@ const createFakeVideoTrack = (
   const stream = canvas.captureStream(fps);
   const [videoTrack] = stream.getVideoTracks();
 
-  // トラックが停止されたらアニメーションも停止する
-  videoTrack.addEventListener("ended", () => {
-    cancelAnimationFrame(animationFrameId);
-    console.log("Animation stopped because track ended.");
-  });
+  // cleanup は idempotent。複数回呼んでも 1 回目以外は no-op にする。
+  // ended ハンドラと #disconnect 経由の明示 cleanup の両方から呼ばれることを想定している。
+  const cleanup = (): void => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    videoTrack.removeEventListener("ended", onEnded);
+    videoTrack.stop();
+    if (animationFrameId !== undefined) {
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = undefined;
+    }
+  };
 
-  return videoTrack;
+  // ended イベントから cleanup を呼ぶことで、track.stop() を外部から呼ばれた場合にも
+  // RAF / リスナーが解放されるようにする。
+  const onEnded = (): void => {
+    cleanup();
+  };
+  videoTrack.addEventListener("ended", onEnded);
+
+  return { track: videoTrack, cleanup };
 };
 
 const createFakeAudioTrack = (
   frequency = 440, // デフォルト周波数 A4 (440Hz)
   volume = 0.1, // デフォルト音量 (0.0 - 1.0)
   stereo = false, // ステレオかモノラルか
-): MediaStreamTrack => {
+): { track: MediaStreamTrack; cleanup: () => void } => {
   // AudioContextを作成
   const audioCtx = new AudioContext();
 
@@ -187,23 +221,28 @@ const createFakeAudioTrack = (
     // MediaStreamからAudioTrackを取得
     const [audioTrack] = destination.stream.getAudioTracks();
 
-    // デバッグ情報
-    console.log("Created stereo audio track:", {
-      channelCount: destination.channelCount,
-      leftFreq: frequency,
-      rightFreq: frequency * 1.5,
-    });
-
-    // トラックが停止されたらAudioContextを閉じる
-    audioTrack.addEventListener("ended", () => {
+    // cleanup は idempotent。複数回呼んでも 1 回目以外は no-op にする。
+    let cleaned = false;
+    const cleanup = (): void => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      audioTrack.removeEventListener("ended", onEnded);
+      audioTrack.stop();
       oscillatorLeft.stop();
       oscillatorRight.stop();
-      void audioCtx.close().then(() => {
-        console.log("AudioContext closed because track ended.");
-      });
-    });
+      // AudioContext.close() は Promise を返すが await すると cleanup の同期性が崩れる。
+      // 失敗時は handleAudioContextCloseError が InvalidStateError 以外を console.error に出す。
+      void audioCtx.close().catch(handleAudioContextCloseError);
+    };
 
-    return audioTrack;
+    const onEnded = (): void => {
+      cleanup();
+    };
+    audioTrack.addEventListener("ended", onEnded);
+
+    return { track: audioTrack, cleanup };
   }
   // モノラルの場合（既存の実装）
   // OscillatorNode（音源）を作成
@@ -228,15 +267,25 @@ const createFakeAudioTrack = (
   // MediaStreamからAudioTrackを取得
   const [audioTrack] = destination.stream.getAudioTracks();
 
-  // トラックが停止されたらAudioContextを閉じる
-  audioTrack.addEventListener("ended", () => {
+  // cleanup は idempotent。複数回呼んでも 1 回目以外は no-op にする。
+  let cleaned = false;
+  const cleanup = (): void => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    audioTrack.removeEventListener("ended", onEnded);
+    audioTrack.stop();
     oscillator.stop();
-    void audioCtx.close().then(() => {
-      console.log("AudioContext closed because track ended.");
-    });
-  });
+    void audioCtx.close().catch(handleAudioContextCloseError);
+  };
 
-  return audioTrack;
+  const onEnded = (): void => {
+    cleanup();
+  };
+  audioTrack.addEventListener("ended", onEnded);
+
+  return { track: audioTrack, cleanup };
 };
 
 // --- getFakeMedia のための型定義 ---
@@ -260,10 +309,16 @@ interface FakeMediaStreamConstraints {
  * @param constraints - 生成するトラックの種類と設定を指定するオブジェクト。
  *   - video: true または { width, height, frameRate } 形式のオブジェクトでビデオトラックを要求します。
  *   - audio: true または { frequency, volume } 形式のオブジェクトでオーディオトラックを要求します。
- * @returns 指定されたトラックを含む MediaStream。要求されたトラックがない場合は空の MediaStream を返します。
+ * @returns
+ *   - stream: 指定されたトラックを含む MediaStream。要求されたトラックがない場合は空の MediaStream を返します。
+ *   - cleanup: 生成したトラックの RAF / AudioContext / Oscillator 等のリソースを解放する関数。
+ *     呼び出し元は disconnect 時に必ず呼ぶこと。cleanup は idempotent。
  */
-export const getFakeMedia = (constraints: FakeMediaStreamConstraints): MediaStream => {
+export const getFakeMedia = (
+  constraints: FakeMediaStreamConstraints,
+): { stream: MediaStream; cleanup: () => void } => {
   const tracks: MediaStreamTrack[] = [];
+  const cleanups: Array<() => void> = [];
 
   if (constraints.video) {
     // デフォルトのビデオ設定
@@ -272,12 +327,13 @@ export const getFakeMedia = (constraints: FakeMediaStreamConstraints): MediaStre
     if (typeof constraints.video === "object") {
       videoOptions = { ...videoOptions, ...constraints.video };
     }
-    const videoTrack = createFakeVideoTrack(
+    const { track, cleanup } = createFakeVideoTrack(
       videoOptions.width,
       videoOptions.height,
       videoOptions.frameRate,
     );
-    tracks.push(videoTrack);
+    tracks.push(track);
+    cleanups.push(cleanup);
   }
 
   if (constraints.audio) {
@@ -287,19 +343,27 @@ export const getFakeMedia = (constraints: FakeMediaStreamConstraints): MediaStre
     if (typeof constraints.audio === "object") {
       audioOptions = { ...audioOptions, ...constraints.audio };
     }
-    const audioTrack = createFakeAudioTrack(
+    const { track, cleanup } = createFakeAudioTrack(
       audioOptions.frequency,
       audioOptions.volume,
       audioOptions.stereo,
     );
-    tracks.push(audioTrack);
+    tracks.push(track);
+    cleanups.push(cleanup);
   }
 
   // 要求されたトラックがない場合、警告を出力（エラーをスローする代わりに）
   if (tracks.length === 0) {
-    console.warn("getFakeMedia called with no tracks requested.");
+    console.warn("getFakeMedia: 要求されたトラックがありません。");
   }
 
   // 生成されたトラックで MediaStream を作成して返す
-  return new MediaStream(tracks);
+  return {
+    stream: new MediaStream(tracks),
+    cleanup: (): void => {
+      for (const fn of cleanups) {
+        fn();
+      }
+    },
+  };
 };

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -12,6 +12,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "stripInternal": true,
+    "skipLibCheck": true,
     "newLine": "LF",
     "types": ["node"],
     "paths": {

--- a/issues/0051-refactor-use-vp-pack-for-library-build.md
+++ b/issues/0051-refactor-use-vp-pack-for-library-build.md
@@ -30,14 +30,14 @@
 
 `vp pack` は tsdown ベースのライブラリ向けビルドコマンドで、現行の `vp build` とは以下の点で異なる。
 
-| 項目 | `vp build` | `vp pack` |
-| --- | --- | --- |
-| 出力ファイル | `dist/sora.js` + 複数 `.d.ts` | `dist/sora.js` + 単一 `sora.d.ts` |
-| minify | `vite.config.ts` の設定が反映 | デフォルト無効、`pack.minify` で明示が必要 |
-| target | `es2022` | `pack.target` で明示が必要 |
-| `__SORA_JS_SDK_VERSION__` | 自動置換 | 自動では置換されない。`pack.define` で再定義が必要 |
-| banner | `rolldownOptions.output.banner` で反映 | `pack.banner` で再定義が必要 |
-| dts | `vite-plugin-dts` で生成 | tsdown 内蔵の dts 生成を使用 |
+| 項目                      | `vp build`                             | `vp pack`                                          |
+| ------------------------- | -------------------------------------- | -------------------------------------------------- |
+| 出力ファイル              | `dist/sora.js` + 複数 `.d.ts`          | `dist/sora.js` + 単一 `sora.d.ts`                  |
+| minify                    | `vite.config.ts` の設定が反映          | デフォルト無効、`pack.minify` で明示が必要         |
+| target                    | `es2022`                               | `pack.target` で明示が必要                         |
+| `__SORA_JS_SDK_VERSION__` | 自動置換                               | 自動では置換されない。`pack.define` で再定義が必要 |
+| banner                    | `rolldownOptions.output.banner` で反映 | `pack.banner` で再定義が必要                       |
+| dts                       | `vite-plugin-dts` で生成               | tsdown 内蔵の dts 生成を使用                       |
 
 ## 設計方針
 

--- a/issues/0053-add-publint-attw-validation.md
+++ b/issues/0053-add-publint-attw-validation.md
@@ -59,7 +59,7 @@ attw: true,
 3. 検出された警告 / エラーを確認し、必要に応じて `package.json` の `exports` 構成を修正する
 4. 許容する警告がある場合は、`pack.publint` / `pack.attw` のオプションで制御するか、issue 内に理由を記載する
 5. `CHANGES.md` の `## develop` セクションの `### misc` に以下を追加する
-   - `[ADD] `vp pack` の `publint` / `attw` 検証を有効化する`
+   - `[ADD] `vp pack`の`publint`/`attw` 検証を有効化する`
 
 ## 関連
 

--- a/issues/0054-change-exports-require-condition.md
+++ b/issues/0054-change-exports-require-condition.md
@@ -62,7 +62,7 @@
 
 2. `pnpm run build` と E2E テストで動作確認を行う
 3. `CHANGES.md` の `## develop` セクションに以下を追加する
-   - `[CHANGE] `exports` から `require` 条件を削除し ESM のみをサポートする`
+   - `[CHANGE] `exports`から`require` 条件を削除し ESM のみをサポートする`
 
 ## 関連
 

--- a/issues/closed/0028-test-fix-fake-track-raf-audiocontext-leak.md
+++ b/issues/closed/0028-test-fix-fake-track-raf-audiocontext-leak.md
@@ -3,6 +3,7 @@
 - Priority: Medium
 - Created: 2026-05-21
 - Polished: 2026-06-14
+- Completed: 2026-06-15
 - Model: Opus 4.7
 - Branch: feature/fix-fake-track-cleanup
 
@@ -356,3 +357,29 @@ document.querySelector("#connect")?.addEventListener("click", async () => {
 ## マージ順
 
 **0029 の前を必須。** 0029 は `fake_stereo_audio` 系 fixture の `getFakeMedia` 呼び出しと `#disconnect` ハンドラを変更するが、それらは本 issue で `getFakeMedia` の戻り値を `{ stream, cleanup }` に変更した後でないとコンパイルできない。0028 を先にマージし、0029 は 0028 マージ後に rebase してから作業を進める。
+
+## 解決方法
+
+### fake.ts
+
+- `createFakeVideoTrack` / `createFakeAudioTrack` の戻り値を `MediaStreamTrack` から `{ track: MediaStreamTrack; cleanup: () => void }` に変更した。`cleanup` は `cleaned` フラグで idempotent にガードし、`videoTrack.removeEventListener("ended", onEnded)` → `videoTrack.stop()` → `cancelAnimationFrame(animationFrameId)` の順で解放する。`updateCanvas()` 冒頭でも `cleaned` をチェックし、`cleanup()` 直後にキューされた RAF コールバックが再スケジュールされないようにした。
+- `createFakeAudioTrack` の stereo / mono 双方で `cleanup` 内に `audioTrack.stop()` / `oscillator.stop()` / `audioCtx.close().catch(handleAudioContextCloseError)` を含めた。`handleAudioContextCloseError` は `InvalidStateError` のみ無視し、それ以外は `console.error` で可視化する共通ヘルパとして抽出した。
+- `getFakeMedia` の戻り値を `MediaStream` から `{ stream: MediaStream; cleanup: () => void }` に変更し、JSDoc の `@returns` にも `cleanup` の責務 (idempotent、disconnect 時に必ず呼ぶ) を明記した。生成した全 track の cleanup を内部で集約する。
+- 既存の `console.log("... because track ended.")` 系のデバッグログを削除し、残りの英語 `console.warn` / `console.error` を日本語化した。
+
+### 呼び出し元 5 ファイル
+
+- `e2e-tests/fake_stereo_audio/main.ts` / `e2e-tests/fake_stereo_audio_sendrecv/main.ts` / `e2e-tests/fake_sendonly/main.ts` / `e2e-tests/sendrecv_webkit/main.ts` / `e2e-tests/simulcast_sendonly_webkit/main.ts` の 5 ファイルに `let fakeCleanup: (() => void) | null = null;` (sendrecv は 2 本) を追加し、`#connect` の `getFakeMedia` 直前で既存 cleanup を解放、`getFakeMedia` の `cleanup` を保持、`#disconnect` 末尾で解放する構造に統一した。
+- `#connect` で `client.connect(stream)` (sendrecv は接続 1 / 接続 2) を try/catch で囲み、connect 失敗時にも `fakeCleanup` を解放して再 throw する。
+- `#disconnect` ハンドラは try/finally で囲み、`client.disconnect` (analyzer の `stop()` を含む) が throw しても finally で `fakeCleanup` が必ず解放されるようにした。`fake_sendonly/main.ts` の `#connect` 冒頭の `if (client) await client.disconnect()` も try/finally で囲んで対称性を取った。
+
+### tsconfig.json
+
+- `e2e-tests/tsconfig.json` に `skipLibCheck: true` を追加して `pnpm --dir e2e-tests run check` が通るようにした。
+
+### 検証
+
+- `pnpm run fmt` / `pnpm run lint` / `pnpm run typecheck` / `pnpm test` / `pnpm run build` / `pnpm --dir e2e-tests run check` がすべて通ることを確認した。
+- `/review-diff-code` を 2 周回し、致命的・重要な指摘 (`ignoreAudioContextCloseError` から `handleAudioContextCloseError` への rename 漏れコメント修正、`fake_stereo_audio_sendrecv/main.ts` の disconnect で analyzer 系を try ブロックに入れる修正、`fake_sendonly/main.ts` の #connect 冒頭を try/finally で囲む修正、コメント表現の小修正) を反映した。
+- ローカル Playwright (signaling URL が必要) と CI workflow `e2e-test.yml` / `e2e-test-webkit.yml` の green 確認は CI に委ねる。
+- リーク解消の手動確認 / `fake_sendonly` の手動確認は本コミットでは未実施。issue 完了条件には残しており、後続でフォローアップ可能。


### PR DESCRIPTION
## 概要

`e2e-tests/src/fake.ts` の `createFakeVideoTrack` / `createFakeAudioTrack` が起動する RAF / AudioContext / OscillatorNode は track の `ended` イベントハンドラ内でのみ解放されており、呼び出し元の 5 fixture は disconnect 時に fake track を停止していないため、同一 page で connect / disconnect を繰り返すとリソースが蓄積する問題を修正する。

## 変更内容

### fake.ts

- `createFakeVideoTrack` / `createFakeAudioTrack` の戻り値を `{ track, cleanup }` に変更し、`cleaned` フラグで idempotent な cleanup を提供する
- `updateCanvas()` 冒頭で `cleaned` をチェックし、cleanup 直後にキューされた RAF コールバックが再スケジュールされないようにする
- `cleanup` は `removeEventListener("ended", onEnded)` → `track.stop()` → RAF / Oscillator / `audioCtx.close()` の順で解放する
- `audioCtx.close()` の Promise rejection は `handleAudioContextCloseError` で `InvalidStateError` のみ無視し、それ以外は `console.error` に出す
- `getFakeMedia` の戻り値を `{ stream, cleanup }` に変更し、生成した全 track の cleanup を集約する
- 削除した英語デバッグログを除き、`console.warn` / `console.error` を日本語化する

### 呼び出し元 5 ファイル

- 各 fixture (`fake_stereo_audio` / `fake_stereo_audio_sendrecv` / `fake_sendonly` / `sendrecv_webkit` / `simulcast_sendonly_webkit`) に `let fakeCleanup: (() => void) \| null = null;` を追加する (sendrecv は 2 本)
- `#connect` 内で `getFakeMedia` 直前に既存 cleanup を解放し、`client.connect(stream)` を try/catch で囲んで失敗時にも fake stream を解放する
- `#disconnect` を try/finally で囲み、`client.disconnect()` が throw しても finally で fakeCleanup が確実に解放されるようにする
- `fake_sendonly` の `#connect` 冒頭の旧 `client.disconnect()` も try/finally で同等に保護する
- `fake_stereo_audio_sendrecv` の disconnect では analyzer.stop() も try ブロック内に入れて他 fixture と整合させる

### tsconfig.json

- `e2e-tests/tsconfig.json` に `skipLibCheck: true` を追加して `pnpm --dir e2e-tests run check` が通るようにする

### 付随する fmt 修正

- pre-commit hook の `vp check` を通すため、develop に既存していた `issues/0051` / `issues/0053` / `issues/0054` の markdown フォーマットエラーを `vp fmt` で同時に解消する (本 issue 本筋とは独立)

## 完了条件

- [x] `e2e-tests/src/fake.ts` の `createFakeVideoTrack` / `createFakeAudioTrack` を `{ track, cleanup }` 返却に変更し `cleaned` フラグでガードする
- [x] `createFakeVideoTrack` の `animationFrameId` を `number \| undefined` にし `updateCanvas()` 冒頭で `cleaned` をチェックする
- [x] `cleanup` 内で `track.stop()` を呼び、`ended` リスナーを除去する
- [x] `audioCtx.close()` に `.catch` を付け `InvalidStateError` 以外は `console.error` に出力する
- [x] `ended` ハンドラから同じ `cleanup` を呼ぶよう共通化する。既存の `console.log("... because track ended.")` は削除する
- [x] `fake.ts` 内の残りの英語 `console.log` / `console.warn` / `console.error` を日本語に変更する
- [x] `getFakeMedia` を `{ stream, cleanup }` 返却に変更し全 track の cleanup を集約する
- [x] `getFakeMedia` の JSDoc `@returns` 注釈を更新する
- [x] 呼び出し元 5 ファイル / 6 箇所を cleanup 保持変数 + `#connect` 代入 + `#disconnect` 呼び出しに更新する
- [x] `#connect` 内で `client.connect(stream)` が失敗した場合も `fakeCleanup()` を呼ぶ (try/catch)
- [x] `e2e-tests/tsconfig.json` に `skipLibCheck: true` を追加し `pnpm --dir e2e-tests run check` が通るようにする
- [x] `pnpm run fmt` / `pnpm run lint` / `pnpm run typecheck` / `pnpm test` / `pnpm run build` / `pnpm --dir e2e-tests run check` が通る
- [x] `CHANGES.md` `## develop` `### misc` 末尾に `[FIX]` エントリを追加する

## 補足

- ローカル Playwright (signaling URL が必要) と `e2e-test.yml` / `e2e-test-webkit.yml` の green 確認は CI に委ねる
- `fake_sendonly/main.ts` の手動確認 (breakpoint で `fakeCleanup` がヒット) とリーク解消の DevTools 手動確認はマージ前に必要に応じて実施する
- `/review-diff-code` を 2 周回し、致命的 (rename 漏れコメント) と重要な指摘 (`fake_stereo_audio_sendrecv` の disconnect analyzer 順序、`fake_sendonly` の `#connect` 旧 client try/finally 化、コメント表現の小修正) を反映済み

## 関連 issue

- issues/closed/0028-test-fix-fake-track-raf-audiocontext-leak.md
- 0029 (stereo audio E2E SDP assert) のマージ前提