### PR TITLE
0033 npm-publish.yml の publish 2 経路に --provenance を追加する

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,7 +74,7 @@ jobs:
       # pnpm publish は CI では正常に動作しない
       # https://github.com/pnpm/pnpm/issues/4937
       - run: npm install -g npm@latest
-      - run: npm publish --no-git-checks --tag canary
+      - run: npm publish --no-git-checks --tag canary --provenance
 
   npm-publish:
     runs-on: ubuntu-slim
@@ -100,7 +100,7 @@ jobs:
       # pnpm publish は CI では正常に動作しない
       # https://github.com/pnpm/pnpm/issues/4937
       - run: npm install -g npm@latest
-      - run: npm publish --no-git-checks
+      - run: npm publish --no-git-checks --provenance
 
   slack_notify:
     needs: [npm-publish-canary, npm-publish]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@
   - @voluntas
 - [ADD] CI に @typescript/native-preview による型検証ジョブを追加する
   - @voluntas
+- [ADD] npm publish に --provenance を追加して supply chain 透明性を向上させる
+  - @voluntas
 - [UPDATE] e2e テストの Node バージョンを 22 / 24 / 26 に更新する
   - Node 25 を Node 26 (LTS) に置き換える
   - @voluntas

--- a/issues/closed/0033-ci-add-npm-publish-provenance.md
+++ b/issues/closed/0033-ci-add-npm-publish-provenance.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-25
+- Completed: 2026-06-15
 - Polished: 2026-06-12
 - Model: Composer 2.5
 - Branch: feature/add-npm-publish-provenance
@@ -151,3 +152,14 @@ publish 2 経路の publish コマンドに `--provenance` を **末尾** で追
 - **0026 (closed, commit `772d1d81`)**: workflow permissions 最小化の上流。publish ジョブレベル `id-token: write` を本 issue が利用する
 - **0039 (open)**: `actions/setup-node` を `setup-vp` に置換。本 issue とは編集箇所が異なり競合しないため、本 issue → 0039 の順を推奨
 - **`--no-git-checks` 削除 issue (未起票)**: 本 issue マージ後にリリース実施者が refactor カテゴリで起票予定 (スコープ外セクション参照)
+
+## 解決方法
+
+`.github/workflows/npm-publish.yml` の publish 2 経路の `npm publish` コマンドに `--provenance` フラグを末尾追加した。
+
+- `npm-publish-canary` ジョブ (`:77`): `npm publish --no-git-checks --tag canary` → `npm publish --no-git-checks --tag canary --provenance`
+- `npm-publish` ジョブ (`:103`): `npm publish --no-git-checks` → `npm publish --no-git-checks --provenance`
+
+設計方針セクションで指示された通り、フラグは末尾に追加して 1 行内 diff を読みやすくし、`--no-git-checks` の位置は変更しない。他のステップ・ジョブ (`verify-version` / `build` / `slack_notify` / 各 `setup-node` / `npm install -g npm@latest` / artifact 系 step / 各 `permissions:`) は無編集。`package.json` も無編集。
+
+完了条件のコード変更 3 項目はすべて充足。検証 4 項目のうち PR diff の確認とジョブレベル `id-token: write` の残存確認はレビューで充足。マージ後の動作確認 (Provenance バッジ表示・`npm audit signatures` での検証等) はマージ後フォローアップセクションに沿って次回 canary tag push 時にリリース実施者が実施する。


### PR DESCRIPTION
## 概要

`.github/workflows/npm-publish.yml` の publish 2 経路 (`npm-publish-canary` / `npm-publish`) の `npm publish` コマンドに `--provenance` フラグを追加し、GitHub Actions から publish した artifact の provenance attestation を npm registry に登録できるようにする。npm の supply chain 対策。SDK の機能・実行時挙動には影響しない。

## 変更内容

- `.github/workflows/npm-publish.yml:77` を `npm publish --no-git-checks --tag canary --provenance` に変更
- `.github/workflows/npm-publish.yml:103` を `npm publish --no-git-checks --provenance` に変更
- `CHANGES.md` `## develop` の `### misc` の `[ADD]` 群末尾に `[ADD] npm publish に --provenance を追加して supply chain 透明性を向上させる` を追記
- issue ファイルを `issues/closed/` に移動し `## 解決方法` と `Completed: 2026-06-15` を追記

末尾追加なので 1 行内 diff が読みやすい。`--no-git-checks` の位置は動かさない。`package.json` は無編集 (`publishConfig.provenance` はスコープ外、ローカル誤実行時に provenance 経路に入るのを避けるため意図的に CLI フラグ方式)。

## 完了条件

### コード変更

- [x] `.github/workflows/npm-publish.yml:77` を `npm publish --no-git-checks --tag canary --provenance` に変更
- [x] `.github/workflows/npm-publish.yml:103` を `npm publish --no-git-checks --provenance` に変更
- [x] 上記 2 箇所以外 (トップレベル `permissions` / ジョブレベル `permissions` / `verify-version` / `build` / `slack_notify` / 各 `setup-node` / `npm install -g npm@latest` / artifact 系 step) は無編集
- [x] `package.json` は無編集

### 検証

- [x] PR diff で `--provenance` の末尾追加が 2 箇所のみで、それ以外の変更が無いことを確認
- [x] 0026 由来のジョブレベル `id-token: write` (`:58` / `:84`) が残存していることを確認
- 本 PR 自身は publish workflow をトリガしないため、provenance 動作の確認はマージ後の next canary tag push 時に行う

### 変更履歴

- [x] `CHANGES.md` `## develop` の `### misc` セクションに `[ADD] npm publish に --provenance を追加して supply chain 透明性を向上させる` を追加 (種別順 CHANGE → ADD → UPDATE → FIX を維持)

## マージ後フォローアップ

リリース実施者が次回 canary tag push 以降で動作確認 (publish ジョブログの `Signed provenance statement` 行、`npm audit signatures --include-attestations`、npmjs.com の Provenance バッジ表示) を行う。失敗時の復旧手順は issue 本文の「マージ後フォローアップ」セクション参照。

## 関連 issue

- `issues/closed/0033-ci-add-npm-publish-provenance.md`
- 0024 (closed): タグ検証 (`verify-version` ジョブ新設) の上流
- 0026 (closed): workflow permissions 最小化の上流。本 PR が publish ジョブレベル `id-token: write` を利用
- 0039 (open): `actions/setup-node` を `setup-vp` に置換。編集箇所が異なり競合しない