### PR TITLE
abendPeerConnectionState() の発火順を他 3 系統と揃え timeline → callback の順にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   - 利用者は `.catch` で reject を受ける必要がある (fire-and-forget で呼んでいる場合は unhandled promise rejection が発生する)
   - 非推奨の `stopAudioTrack` / `stopVideoTrack`、および `replaceAudioTrack` / `replaceVideoTrack` 経由でも同じ reject が伝播する
   - @voluntas
+- [CHANGE] `abendPeerConnectionState()` の発火順を他 3 系統と揃え timeline → callback の順にする
+  - @voluntas
 - [UPDATE] pnpm 11 系に上げる
   - @voluntas
 - [UPDATE] TypeScript 6.0 へ対応する

--- a/issues/closed/0042-change-abend-peer-connection-state-callback-order.md
+++ b/issues/closed/0042-change-abend-peer-connection-state-callback-order.md
@@ -2,7 +2,7 @@
 
 - Priority: Low
 - Created: 2026-06-09
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/change-abend-peer-connection-state-callback-order
 - Polished: 2026-06-16
@@ -114,4 +114,7 @@ this.writeSoraTimelineLog("disconnect-abend", event);
 
 ## 解決方法
 
-実装完了後に追記する (どのファイルをどう変更したかの実績)。
+- `src/base.ts:697-698` の 2 行を入れ替え、`abendPeerConnectionState()` の発火順を他 3 系統 (`shutdown` / `abend` / `disconnect`) と揃えて `writeSoraTimelineLog` → `callbacks.disconnect` の順にした。`event` 生成 (`:696`) はそのまま、参照同一性も維持。
+- `:645-695` (handler 剥がし、DataChannel close、`ws.close()`、`pc.close()`、`initializeConnection`) は変更なし。
+- `CHANGES.md` `## develop` 配下、`[CHANGE]` 群末尾 (`removeAudioTrack` / `removeVideoTrack` 担当者行の直後、`[UPDATE] pnpm 11 系に上げる` の直前) に `[CHANGE]` エントリを 1 件追加した。
+- `pnpm test` (108 件 pass) / `pnpm typecheck` / `pnpm lint` をローカルで通過。`grep -nE 'writeSoraTimelineLog\("disconnect-abend"|callbacks\.disconnect' src/base.ts | head -2` の結果が `:697 writeSoraTimelineLog → :698 callbacks.disconnect` で issue の機械的確認も満たした。

--- a/src/base.ts
+++ b/src/base.ts
@@ -694,8 +694,8 @@ export default class ConnectionBase {
     }
     this.initializeConnection();
     const event = this.soraCloseEvent("abend", title);
-    this.callbacks.disconnect(event);
     this.writeSoraTimelineLog("disconnect-abend", event);
+    this.callbacks.disconnect(event);
   }
 
   /**


### PR DESCRIPTION
## 概要

`abendPeerConnectionState()` のみ `callback → timeline` 順で発火していたのを、他 3 系統 (`abend` / `shutdown` / `disconnect`) と揃え `timeline → callback` の順に変更する。後方互換のない `[CHANGE]` だが、`callbacks.disconnect` ハンドラ内から timeline 末尾を読むコードのみが影響する観測可能挙動の差。

## 変更内容

- `src/base.ts:697-698` の 2 行を入れ替え、`writeSoraTimelineLog` → `callbacks.disconnect` の順にした
- `event` 生成 (`:696`) はそのままで、`timeline` と `callback` で同一インスタンスを共有する参照同一性を維持
- `:645-695` (handler 剥がし、DataChannel close、`ws.close()`、`pc.close()`、`initializeConnection`) は変更なし
- `CHANGES.md` `## develop` 配下、`[CHANGE]` 群末尾に `[CHANGE]` エントリを 1 件追加

## 完了条件

- [x] `src/base.ts:697-698` の発火順が `writeSoraTimelineLog` → `callbacks.disconnect` になる
- [x] ローカルで `pnpm test` が通る (108 件 pass)
- [x] `CHANGES.md` `## develop` 配下、`[CHANGE]` 群末尾に `[CHANGE]` エントリを追記する

## 関連 issue

- issues/closed/0042-change-abend-peer-connection-state-callback-order.md