### PR TITLE
createSignalingMessage の audio / video パラメータ判定で X in copyOptions を typeof / !== undefined ガードに置き換える

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,9 @@
   - @voluntas
 - [UPDATE] `DisconnectWaitTimeoutError` / `DisconnectInternalError` / `DisconnectDataChannelError` の constructor で `name` プロパティをクラス名に設定するようにする
   - @voluntas
+- [UPDATE] `createSignalingMessage` の audio / video パラメータ判定で `"X" in copyOptions` を `typeof` / `!== undefined` ガードに置き換える
+  - 型安全化リファクタで動的挙動の変化はなし
+  - @voluntas
 - [FIX] Node 24 で `playwright install` がハングする問題を修正するため Playwright を 1.60.0 に更新する
   - @voluntas
 - [FIX] macOS の Google Chrome stable インストールが 302 リダイレクトを追従できず失敗するため playwright-core にパッチを当てて `curl` に `-L` を追加する

--- a/issues/closed/0046-refactor-create-signaling-message-typeof-guard.md
+++ b/issues/closed/0046-refactor-create-signaling-message-typeof-guard.md
@@ -3,6 +3,7 @@
 - Priority: Medium
 - Created: 2026-06-11
 - Polished: 2026-06-16
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/refactor-create-signaling-message-typeof-guard
 
@@ -123,4 +124,12 @@ if (copyOptions.videoVP9Params !== undefined) {
 
 ## 解決方法
 
-実装完了後に追記する (どのファイルをどう変更したかの実績)。
+- `src/utils.ts` の `createSignalingMessage` 内 16 箇所を設計方針の表 (:43-48) に従ったガードに置き換えた。
+  - string 系 2 件 (`audioCodecType` / `videoCodecType`): `typeof copyOptions.X === "string"`
+  - number 系 6 件 (`audioBitRate` / `audioOpusParamsChannels` / `audioOpusParamsMaxplaybackrate` / `audioOpusParamsMinptime` / `audioOpusParamsPtime` / `videoBitRate`): `typeof copyOptions.X === "number"`
+  - boolean 系 4 件 (`audioOpusParamsStereo` / `audioOpusParamsSpropStereo` / `audioOpusParamsUseinbandfec` / `audioOpusParamsUsedtx`): `typeof copyOptions.X === "boolean"`
+  - JSONType 系 4 件 (`videoVP9Params` / `videoH264Params` / `videoH265Params` / `videoAV1Params`): `copyOptions.X !== undefined`
+- audio / audio_opus_params / video の 3 ブロック先頭に、typeof ガードと事前 delete ループとの依存関係を説明する日本語コメントを追加した。
+- `grep -nE '"[A-Za-z0-9]+" in copyOptions' src/utils.ts` が 0 件であることを確認した (issue 完了条件で指定された `[A-Za-z]+` パターンは数字を含む `videoVP9Params` 等 4 件を見逃すため、`[A-Za-z0-9]+` で再確認した)。
+- `CHANGES.md` の `## develop` `### misc` 内、`[UPDATE]` 群末尾に `[UPDATE]` エントリを 1 件追加した。
+- 完了条件で指定された `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm fmt` を順序通り実行し、すべて pass・fmt 後の追加差分が無いことを確認した。テスト 108 件すべて pass。

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -267,10 +267,12 @@ export function createSignalingMessage(
   const hasAudioProperty = Object.keys(copyOptions).some((key) => audioPropertyKeys.includes(key));
   if (message.audio && hasAudioProperty) {
     message.audio = {};
-    if ("audioCodecType" in copyOptions) {
+    // ConnectionOptions の各キーの型に沿った typeof ガードで narrow する。
+    // null は事前の delete ループで除去済みのため、typeof 系で弾かれても message に積む値の集合は不変。
+    if (typeof copyOptions.audioCodecType === "string") {
       message.audio.codec_type = copyOptions.audioCodecType;
     }
-    if ("audioBitRate" in copyOptions) {
+    if (typeof copyOptions.audioBitRate === "number") {
       message.audio.bit_rate = copyOptions.audioBitRate;
     }
   }
@@ -282,28 +284,29 @@ export function createSignalingMessage(
       message.audio = {};
     }
     message.audio.opus_params = {};
-    if ("audioOpusParamsChannels" in copyOptions) {
+    // 各キーの型に沿った typeof ガードで narrow する。null 事前 delete 前提は audio セクションと同じ。
+    if (typeof copyOptions.audioOpusParamsChannels === "number") {
       message.audio.opus_params.channels = copyOptions.audioOpusParamsChannels;
     }
-    if ("audioOpusParamsMaxplaybackrate" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsMaxplaybackrate === "number") {
       message.audio.opus_params.maxplaybackrate = copyOptions.audioOpusParamsMaxplaybackrate;
     }
-    if ("audioOpusParamsStereo" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsStereo === "boolean") {
       message.audio.opus_params.stereo = copyOptions.audioOpusParamsStereo;
     }
-    if ("audioOpusParamsSpropStereo" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsSpropStereo === "boolean") {
       message.audio.opus_params.sprop_stereo = copyOptions.audioOpusParamsSpropStereo;
     }
-    if ("audioOpusParamsMinptime" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsMinptime === "number") {
       message.audio.opus_params.minptime = copyOptions.audioOpusParamsMinptime;
     }
-    if ("audioOpusParamsPtime" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsPtime === "number") {
       message.audio.opus_params.ptime = copyOptions.audioOpusParamsPtime;
     }
-    if ("audioOpusParamsUseinbandfec" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsUseinbandfec === "boolean") {
       message.audio.opus_params.useinbandfec = copyOptions.audioOpusParamsUseinbandfec;
     }
-    if ("audioOpusParamsUsedtx" in copyOptions) {
+    if (typeof copyOptions.audioOpusParamsUsedtx === "boolean") {
       message.audio.opus_params.usedtx = copyOptions.audioOpusParamsUsedtx;
     }
   }
@@ -314,22 +317,24 @@ export function createSignalingMessage(
   const hasVideoProperty = Object.keys(copyOptions).some((key) => videoPropertyKeys.includes(key));
   if (message.video && hasVideoProperty) {
     message.video = {};
-    if ("videoCodecType" in copyOptions) {
+    // video*Params は JSONType (null 値も透過する型定義) のため typeof === "object" ではなく !== undefined で narrow する。
+    // それ以外のキーは ConnectionOptions の型に沿った typeof ガード。null は事前 delete ループで除去済み。
+    if (typeof copyOptions.videoCodecType === "string") {
       message.video.codec_type = copyOptions.videoCodecType;
     }
-    if ("videoBitRate" in copyOptions) {
+    if (typeof copyOptions.videoBitRate === "number") {
       message.video.bit_rate = copyOptions.videoBitRate;
     }
-    if ("videoVP9Params" in copyOptions) {
+    if (copyOptions.videoVP9Params !== undefined) {
       message.video.vp9_params = copyOptions.videoVP9Params;
     }
-    if ("videoH264Params" in copyOptions) {
+    if (copyOptions.videoH264Params !== undefined) {
       message.video.h264_params = copyOptions.videoH264Params;
     }
-    if ("videoH265Params" in copyOptions) {
+    if (copyOptions.videoH265Params !== undefined) {
       message.video.h265_params = copyOptions.videoH265Params;
     }
-    if ("videoAV1Params" in copyOptions) {
+    if (copyOptions.videoAV1Params !== undefined) {
       message.video.av1_params = copyOptions.videoAV1Params;
     }
   }


### PR DESCRIPTION
## 概要

`createSignalingMessage` の audio / video パラメータ判定で使われている `"X" in copyOptions` 16 箇所を、`ConnectionOptions` 各キーの型に沿った `typeof` / `!== undefined` ガードに置き換える型安全化リファクタ。動的挙動は不変。

## 変更内容

- `src/utils.ts` の 16 箇所を設計方針の表に従ったガードに置換
  - string 系 2 件 (`audioCodecType` / `videoCodecType`): `typeof X === "string"`
  - number 系 6 件 (`audioBitRate` / `audioOpusParamsChannels` / `audioOpusParamsMaxplaybackrate` / `audioOpusParamsMinptime` / `audioOpusParamsPtime` / `videoBitRate`): `typeof X === "number"`
  - boolean 系 4 件 (`audioOpusParamsStereo` / `audioOpusParamsSpropStereo` / `audioOpusParamsUseinbandfec` / `audioOpusParamsUsedtx`): `typeof X === "boolean"`
  - JSONType 系 4 件 (`videoVP9Params` / `videoH264Params` / `videoH265Params` / `videoAV1Params`): `X !== undefined`
- audio / audio_opus_params / video の 3 ブロック先頭に typeof ガードと事前 delete ループとの依存関係を説明するコメント追加
- `CHANGES.md` `## develop` `### misc` 内、`[UPDATE]` 群末尾に `[UPDATE]` エントリ 1 件追加

## 完了条件

- [x] `src/utils.ts` の 16 箇所すべてを設計方針の表に従ったガードに置き換える
- [x] `grep -nE '"[A-Za-z0-9]+" in copyOptions' src/utils.ts` の出力が 0 件
- [x] 既存テスト `tests/utils.test.ts` 全件が修正なしで pass (108 件 pass)
- [x] 新規テストは追加しない (動的挙動不変のため)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm fmt` をすべて通過し、fmt 後の追加差分なし
- [x] `CHANGES.md` `## develop` `### misc` 内、`[UPDATE]` 群末尾に `[UPDATE]` エントリ 1 件追記

## 補足

issue 完了条件の `grep` パターン `[A-Za-z]+` は数字を含む 4 件 (`videoVP9Params` 等) を見逃すため、`[A-Za-z0-9]+` パターンで再確認。

## 関連 issue

- issues/closed/0046-refactor-create-signaling-message-typeof-guard.md