### PR TITLE
Node.js エンジン要件を 22.18.0 以上に引き上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@
   - @voluntas
 - [CHANGE] `abendPeerConnectionState()` の発火順を他 3 系統と揃え timeline → callback の順にする
   - @voluntas
+- [CHANGE] Node.js の最低要件を 22.18.0 以上に引き上げる
+  - 後続のビルドツール移行で導入される `tsdown` 0.22 系が Node.js `^22.18.0 || >=24.0.0` を要求するため
+  - <https://www.npmjs.com/package/tsdown>
+  - @voluntas
 - [UPDATE] pnpm 11 系に上げる
   - @voluntas
 - [UPDATE] TypeScript 6.0 へ対応する

--- a/issues/closed/0052-change-raise-engines-node-to-22-18-0.md
+++ b/issues/closed/0052-change-raise-engines-node-to-22-18-0.md
@@ -2,7 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-06-14
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/change-raise-engines-node-to-22-18-0
 - Polished: 2026-06-16
@@ -103,4 +103,7 @@ Node 22.0 - 22.17 を使い続ける利用者は、本リリース以降 `engine
 
 ## 解決方法
 
-実装完了後に追記する (どのファイルをどう変更したかの実績)。
+- `package.json` の `engines.node` を `">=22"` から `">=22.18.0"` に変更した。`engines.pnpm` は `">=11"` のまま据え置き。
+- `CHANGES.md` の `## develop` 配下、`[CHANGE]` 群末尾 (`abendPeerConnectionState` エントリの直後、`[UPDATE] pnpm 11 系に上げる` の直前) に `[CHANGE]` エントリ 1 件を追加した。
+- 完了条件テンプレ (`:84`) に元々書かれていた `(issue 0051)` という issue 番号への参照は `shiguredo-issues` 規約 (`CHANGES.md` に issue 番号への参照を書いてはいけない) に違反するため、実装時に「後続のビルドツール移行で導入される `tsdown` 0.22 系が要求するため」のように issue 番号を含まない理由表現に書き換えた。
+- ローカルで `pnpm install --frozen-lockfile` / `pnpm typecheck` / `pnpm lint` / `pnpm test` (108 件 pass) / `pnpm fmt` を順序通り通過させ、fmt 後の追加差分が無いことを確認した。

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vite-plus": "0.1.24"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=22.18.0",
     "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.5.2"


### PR DESCRIPTION
## 概要

`package.json` の `engines.node` を `">=22"` から `">=22.18.0"` に引き上げ、利用者契約として Node.js 22.18.0 以上を要求する。後続のビルドツール移行で導入される `tsdown` 0.22 系の `engines.node` 要件 (`^22.18.0 || >=24.0.0`) に SDK の利用者契約を揃える。

## 変更内容

- `package.json` の `engines.node` を `">=22"` → `">=22.18.0"` に変更 (1 行)
- `engines.pnpm` は `">=11"` のまま据え置き
- `CHANGES.md` の `## develop` 配下、`[CHANGE]` 群末尾に `[CHANGE]` エントリ 1 件追加

## 完了条件

- [x] `package.json` の `engines.node` が `">=22.18.0"` になっている
- [x] `package.json` の `engines.pnpm` は本 PR で変更されていない (`">=11"` のまま)
- [x] `package.json` 以外のファイル (workflows / docs 等) に差分が無い (CHANGES.md を除く)
- [x] ローカルで `pnpm install --frozen-lockfile` 成功
- [x] `CHANGES.md` `## develop` 配下、`[CHANGE]` 群末尾に `[CHANGE]` エントリ追記
- [x] `pnpm test` (108 件 pass) / `pnpm typecheck` / `pnpm lint` 通過
- [x] `pnpm fmt` 後の追加差分なし

## 関連 issue

- issues/closed/0052-change-raise-engines-node-to-22-18-0.md