### PR TITLE
package.json の exports から require 条件を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@
   - 後続のビルドツール移行で導入される `tsdown` 0.22 系が Node.js `^22.18.0 || >=24.0.0` を要求するため
   - <https://www.npmjs.com/package/tsdown>
   - @voluntas
+- [CHANGE] `package.json` の `exports["."]` から `require` 条件を削除し ESM のみをサポートする
+  - `require("sora-js-sdk")` は元から `ERR_REQUIRE_ESM` で失敗していたが、削除後は `ERR_PACKAGE_PATH_NOT_EXPORTED` でエラーメッセージが変わる
+  - CJS で利用していたコードは `import` または `await import()` に置き換える必要がある
+  - @voluntas
 - [UPDATE] pnpm 11 系に上げる
   - @voluntas
 - [UPDATE] TypeScript 6.0 へ対応する

--- a/issues/closed/0054-change-exports-require-condition.md
+++ b/issues/closed/0054-change-exports-require-condition.md
@@ -2,7 +2,7 @@
 
 - Priority: Low
 - Created: 2026-06-14
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/change-exports-require-condition
 - Polished: 2026-06-16
@@ -138,4 +138,10 @@ TypeScript `moduleResolution` 別の影響:
 7. `CHANGES.md` の `## develop` 直系 `[CHANGE]` 群末尾に上記エントリを追記する
 8. CI で Build / Test ジョブが正常に完了することを確認する
 
-実績 (実装完了後に追記):
+実績:
+
+- `package.json` の `exports["."]` から `"require": "./dist/sora.js"` の 1 行を削除した。条件キーの順序は `types` → `import` を維持。
+- `CHANGES.md` の `## develop` 配下、`[CHANGE]` 群末尾 (`Node.js の最低要件を 22.18.0` エントリの直後、`[UPDATE] pnpm 11 系に上げる` の直前) に `[CHANGE]` エントリ 1 件を追加した。
+- ローカルで `pnpm build` (`dist/sora.js` 58.31 kB / gzip 11.94 kB) / `pnpm typecheck` / `pnpm lint` / `pnpm test` (108 件 pass) / `pnpm fmt` を順序通り通過。fmt 後の追加差分なし。`npm pkg get exports` の出力で `exports["."]` に `require` キーが消えていることを確認した。
+- `pnpm e2e-test` (chromium) はローカルでは実行せず、CI に委ねる方針とした。
+- `main` / `module` フィールドの扱いは issue 0054 のスコープ外 (`:85-87` 参照) として残置。0053 (`publint` / `attw` 有効化) 着手時に検出される警告に基づいて follow-up issue で対処する。

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "exports": {
     ".": {
       "types": "./dist/sora.d.ts",
-      "import": "./dist/sora.js",
-      "require": "./dist/sora.js"
+      "import": "./dist/sora.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## 概要

`package.json` の `exports["."]` から `"require": "./dist/sora.js"` の 1 行を削除し、ESM 専用 SDK として整合させる。`sora-js-sdk` は `"type": "module"` の ESM 専用 SDK のため、`require("sora-js-sdk")` は元から `ERR_REQUIRE_ESM` で失敗していた。後方互換のない `[CHANGE]` だが利用者影響は実質ゼロ (元から動作していない経路)。

## 変更内容

- `package.json` の `exports["."]` から `"require": "./dist/sora.js"` の 1 行削除
- 条件キーの順序は `types` → `import` を維持 (attw の types-first 規約に準拠)
- `CHANGES.md` の `## develop` 配下、`[CHANGE]` 群末尾に `[CHANGE]` エントリ 1 件追加

## 完了条件

- [x] `package.json` の `exports["."]` から `require` 条件が削除されている
- [x] 条件キーの順序は `types` → `import` を維持
- [x] `pnpm build` / `pnpm typecheck` / `pnpm lint` / `pnpm test` (108 件 pass)
- [x] `npm pkg get exports` の出力で `require` キーが消えていることを確認
- [x] `pnpm fmt` 後の追加差分なし
- [x] `CHANGES.md` `## develop` の `[CHANGE]` 群末尾に `[CHANGE]` エントリ追記
- [ ] `pnpm e2e-test` (chromium) はローカル未実行で CI に委ねる

## 補足

`main` / `module` フィールドの扱いは本 PR のスコープ外 (publint / attw 有効化時に検出される警告に基づいて follow-up で扱う)。

## 関連 issue

- issues/closed/0054-change-exports-require-condition.md