### PR TITLE
.github/workflows/npm-publish.yml の --no-git-checks フラグを削除する

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,7 +74,7 @@ jobs:
       # pnpm publish は CI では正常に動作しない
       # https://github.com/pnpm/pnpm/issues/4937
       - run: npm install -g npm@latest
-      - run: npm publish --no-git-checks --tag canary --provenance
+      - run: npm publish --tag canary --provenance
 
   npm-publish:
     runs-on: ubuntu-slim
@@ -100,7 +100,7 @@ jobs:
       # pnpm publish は CI では正常に動作しない
       # https://github.com/pnpm/pnpm/issues/4937
       - run: npm install -g npm@latest
-      - run: npm publish --no-git-checks --provenance
+      - run: npm publish --provenance
 
   slack_notify:
     needs: [npm-publish-canary, npm-publish]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,9 @@
   - @voluntas
 - [FIX] e2e-tests の fake media 生成に明示的 cleanup() を追加し connect/disconnect 繰り返し時の RAF / AudioContext リークを防ぐ
   - @voluntas
+- [FIX] `.github/workflows/npm-publish.yml` から `--no-git-checks` フラグを削除する
+  - npm 11 で `npm warn Unknown cli config "--git-checks". This will stop working in the next major version of npm.` warning が出ており、npm v12 で publish が break する前に対処する
+  - @voluntas
 
 ## 2025.2.0
 

--- a/issues/closed/0058-refactor-remove-no-git-checks-flag.md
+++ b/issues/closed/0058-refactor-remove-no-git-checks-flag.md
@@ -2,7 +2,7 @@
 
 - Priority: Low
 - Created: 2026-06-15
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-16
 - Model: Opus 4.7
 - Branch: feature/refactor-remove-no-git-checks-flag
 - Polished: 2026-06-16
@@ -144,4 +144,17 @@ publish が失敗した場合の復旧手順 (0033 と同等):
 6. PR 作成・レビュー・squash merge する
 7. マージ後フォローアップ (上記セクション) を次回 publish タイミングでリリース実施者が確認する
 
-実績 (実装完了後に追記):
+実績:
+
+- 事前調査 Step 1 を実施した。
+  - `git blame .github/workflows/npm-publish.yml` で経緯確認: `7ec64660` (2025-05-05) の workflow 新規作成時から `--no-git-checks` が付いていた。同 commit のコメントに `# pnpm publish は CI では正常に動作しない / https://github.com/pnpm/pnpm/issues/4937` とあり、元々 `pnpm publish` 用の現役フラグが `npm publish` に切り替わった際に残置された格好。
+  - `.gitignore` に `dist/` が含まれていることを確認 (`.npmignore` は無く、`package.json` の `files: ["dist"]` で制御)。
+  - ローカルで `npm publish --dry-run --tag canary` を `--no-git-checks` ありとなしの両方で実行: あり = `npm warn Unknown cli config "--git-checks". This will stop working in the next major version of npm.` warning、なし = warning 無しで正常完了。`npm config get git-checks` は `undefined` で npm 11 にはこの config 項目自体が存在しない。
+  - 判定: case A (単純削除可能)。
+- `.github/workflows/npm-publish.yml:77` の `npm publish --no-git-checks --tag canary --provenance` から `--no-git-checks` を削除した。
+- `.github/workflows/npm-publish.yml:103` の `npm publish --no-git-checks --provenance` から `--no-git-checks` を削除した。
+- `grep -n "no-git-checks\|git-checks" .github/workflows/npm-publish.yml` の結果が 0 件であることを確認した。
+- `# pnpm publish は CI では正常に動作しない` のコメント (`:74`, `:100`) は 0055 のスコープのため触っていない。
+- `CHANGES.md` の `## develop` 配下、`### misc` 内 `[FIX]` 群末尾 (`e2e-tests の fake media 生成に明示的 cleanup()...` エントリの直後、`## 2025.2.0` の直前) に `[FIX]` エントリ 1 件を追加した。
+- `pnpm fmt` 後の追加差分なしを確認した。
+- 動作確認 (本 PR では実施しない): publish workflow は tag push でのみ起動するため、マージ後フォローアップで次回 canary tag push 時に warning 消失と publish 成功を確認する。


### PR DESCRIPTION
## 概要

`.github/workflows/npm-publish.yml` の publish 2 経路 (`npm-publish-canary` / `npm-publish`) から `--no-git-checks` フラグを削除する。元々 `pnpm publish` 用の現役フラグが `npm publish` に切り替わった際に残置されたもので、npm 11 では Unknown cli config として warning が出るだけの死フラグだった。npm v12 で publish が break する前に対処する。

## 変更内容

- `.github/workflows/npm-publish.yml:77` の `npm publish --no-git-checks --tag canary --provenance` から `--no-git-checks` を削除
- `.github/workflows/npm-publish.yml:103` の `npm publish --no-git-checks --provenance` から `--no-git-checks` を削除
- `CHANGES.md` `### misc` 内 `[FIX]` 群末尾に `[FIX]` エントリ 1 件追加

## 事前調査結果 (case A 単純削除可能)

- 経緯: `7ec64660` (2025-05-05) で workflow 新規作成時から `pnpm publish` 用フラグとして付いていた。pnpm の issue #4937 を回避するため `npm publish` に切り替えた際にそのまま残置。
- `.gitignore` に `dist/` カバー済み。`.npmignore` は無く `package.json` の `files: ["dist"]` で制御。
- ローカル `npm publish --dry-run --tag canary` で `--no-git-checks` なしで warning なし・publish 成功確認済み (npm 11.13.0、`npm config get git-checks` = `undefined`)。

## 完了条件

- [x] publish 2 経路から `--no-git-checks` を削除
- [x] `.github/workflows/npm-publish.yml` 以外への変更なし (CHANGES.md は除く)
- [x] `CHANGES.md` `### misc` 内 `[FIX]` 群末尾に `[FIX]` エントリ追記
- [ ] 動作確認はマージ後フォローアップ (publish workflow は tag push でのみ起動)

## マージ後フォローアップ

次回 canary tag push (2026.1.0-canary.3 等) で以下をリリース実施者 (@voluntas) が確認:

- canary publish ログに `npm warn Unknown cli config "--git-checks"` warning が出ないこと
- canary publish 自体が成功
- latest tag push でも同様に warning なしで publish が成功すること

## 関連 issue

- issues/closed/0058-refactor-remove-no-git-checks-flag.md