### PR TITLE
@playwright/test を 1.61.1 に固定する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    # @playwright/test 1.62.1 に同梱される WebKit エンジン (r2336) で
+    # RTCPeerConnection がハングし WebKit の E2E テストが失敗するため固定する
+    # 修正版のリリースを確認してから固定を解除する
+    ignore:
+      - dependency-name: "@playwright/test"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "doc": "typedoc"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.61.1",
     "@types/node": "26.1.2",
     "jsdom": "30.0.1",
     "typedoc": "0.28.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: 1.62.1
-        version: 1.62.1
+        specifier: 1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -420,9 +420,9 @@ packages:
     resolution: {integrity: sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@playwright/test@1.62.1':
-    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
-    engines: {node: '>=20'}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@polka/url@1.0.0-next.29':
@@ -1249,14 +1249,14 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
-    engines: {node: '>=20'}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.62.1:
-    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
-    engines: {node: '>=20'}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -1762,9 +1762,9 @@ snapshots:
 
   '@oxlint/plugins@1.73.0': {}
 
-  '@playwright/test@1.62.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.62.1
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -2386,11 +2386,11 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  playwright-core@1.62.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.62.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.62.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## 背景

8/9 の依存ライブラリ更新 (@playwright/test 1.61.1 → 1.62.1) 以降、e2e-test-webkit が毎回失敗している。

## 原因

Playwright 1.62.1 に同梱される WebKit エンジン (r2336) のリグレッション。WebKit で Sora へのシグナリング接続時に RTCPeerConnection 生成直後から処理がハングし、Sora 側が answer を 10 秒待てず WebSocket を切断する。

検証結果:
- @playwright/test 1.62.1 (WebKit r2336): 全 run 失敗
- @playwright/test 1.61.1 (WebKit r2311): 成功 (2 passed)

self-hosted ランナー環境の問題ではなく、WebKit エンジンのリグレッションであることを確認済み。

## 対応

- @playwright/test を 1.61.1 に固定する
- Dependabot の更新対象から除外する (修正版のリリース確認後に固定解除する)